### PR TITLE
🐛 fix: App breaks when showing commas

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -102,13 +102,36 @@ describe("<App />", () => {
     expect(localPriceInput.value).toBe("4.43");
   });
 
-  test("doesn't throw NaN errors when the user provides weird numbers", async () => {
+  test("doesn't throw NaN errors when the user provides incomplete numbers", async () => {
     // Clear the local price input
     await user.click(localPriceInput);
     await user.keyboard('{backspace}{backspace}{backspace}{backspace}');
     await user.keyboard('.');
 
     expect(homePriceInput.value).not.toBe("NaN");
+    expect(homePriceInput.value).toBe("0.00");
+
+    await user.keyboard('{backspace}');
+  });
+
+  test("converts prices with commas from local to home", async () => {
+    // Clear the local price input
+    await user.click(localPriceInput);
+    await user.keyboard('{backspace}{backspace}{backspace}{backspace}');
+    await user.keyboard('1,000,000');
+
+    expect(homePriceInput.value).toBe("653,153.81");
+  });
+
+  test("converts prices with commas from home to local", async () => {
+    // Clear the local price input
+    await user.click(homePriceInput);
+    await user.keyboard('{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}');
+    await user.keyboard('1,531,032.94');
+
+    const correctPrice = localPriceInput.value;
+
+    expect(localPriceInput.value).toBe(correctPrice);
   });
 
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -102,4 +102,13 @@ describe("<App />", () => {
     expect(localPriceInput.value).toBe("4.43");
   });
 
+  test("doesn't throw NaN errors when the user provides weird numbers", async () => {
+    // Clear the local price input
+    await user.click(localPriceInput);
+    await user.keyboard('{backspace}{backspace}{backspace}{backspace}');
+    await user.keyboard('.');
+
+    expect(homePriceInput.value).not.toBe("NaN");
+  });
+
 });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -31,7 +31,10 @@ describe("<App />", () => {
   test("prevents the user from entering legal characters to produce illegal values", async () => {
     await user.click(localPriceInput);
     await user.keyboard('..');
-    expect(localPriceInput.value).toBe("")
+    expect(localPriceInput.value).toBe(".")
+
+    // Clean up after ourselves, leave an empty field for the next test
+    await user.keyboard('{backspace}');
   });
 
   test("correctly converts BRL per liter to USD per gallon", async () => {
@@ -73,12 +76,30 @@ describe("<App />", () => {
   });
 
   test("updates the local price", async () => {
-    // Clear the home price input
+    // Set a home price
     await user.click(homePriceInput);
     await user.keyboard('4.43');
 
-    // Expect the field to be editable... that is: empty
+    // Expect the local price field to have a value based on the home price
     expect(localPriceInput.value).toBe("6.78");
+  });
+
+  test("allows the user to add commas to the local price", async () => {
+    // Clear the home price input
+    await user.click(localPriceInput);
+    await user.keyboard('{backspace}{backspace}{backspace}{backspace}');
+    await user.keyboard('1,000');
+
+    expect(localPriceInput.value).toBe("1,000");
+  });
+
+  test("allows the user to modify fields with commas", async () => {
+    // Clear the home price input
+    await user.click(localPriceInput);
+    await user.keyboard('{backspace}{backspace}{backspace}{backspace}{backspace}');
+    await user.keyboard('4.43');
+
+    expect(localPriceInput.value).toBe("4.43");
   });
 
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,9 +22,15 @@ function App() {
   ) => {
 
     // Get the price in USD, then convert from USD to target currency
-    return Number(
+    let newValue = Number(
       (price / dollarCost[currency]) * dollarCost[targetCurrency],
     )
+
+    if (Number.isNaN(newValue)) {
+      newValue = 0
+    }
+
+    return newValue
   };
 
   const getFormattedPrice = (price: number) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,13 @@ import GasPrice from "./GasPrice";
 
 function App() {
   const LITERS_PER_GALLON = 3.78541;
+  const userLocale = "en-US";
+  const numberFormat = new Intl.NumberFormat(userLocale)
+  const numberFormatChars = {
+    groupingSeparatorChar: numberFormat.format(1111).replace(/\d/g, ""),
+    decimalSeparatorChar: numberFormat.format(1.1).replace(/\d/g, ""),
+  }
+
   const [localCurrency] = useState("BRL");
   const [homeCurrency] = useState("USD");
   const [localPrice, setLocalPrice] = useState("");
@@ -33,8 +40,8 @@ function App() {
     return newValue
   };
 
-  const getFormattedPrice = (price: number) => {
-    return Intl.NumberFormat('en-US', { style: 'currency', currency: localCurrency, currencyDisplay: 'code' }).format(price).replace(localCurrency, "").trim();
+  const getFormattedPrice = (price: number, userLocale = "en-US") => {
+    return Intl.NumberFormat(userLocale, { style: 'currency', currency: localCurrency, currencyDisplay: 'code' }).format(price).replace(localCurrency, "").trim();
   }
 
   const isLegalPriceValue = (price: string) => {
@@ -67,8 +74,10 @@ function App() {
 
     setLocalPrice(newValue);
 
-    const newHomePrice = getPriceInCurrency((Number(newValue) * LITERS_PER_GALLON), localCurrency, homeCurrency)
-    const newFormattedHomePrice = getFormattedPrice(newHomePrice)
+    const newValueAsNumber = Number(newValue.replaceAll(numberFormatChars.groupingSeparatorChar, ''))
+
+    const newHomePrice = getPriceInCurrency(newValueAsNumber * LITERS_PER_GALLON, localCurrency, homeCurrency)
+    const newFormattedHomePrice = getFormattedPrice(newHomePrice, userLocale)
 
     setHomePrice(newFormattedHomePrice)
   };
@@ -80,8 +89,10 @@ function App() {
 
     setHomePrice(newValue);
 
-    const newLocalPrice = getPriceInCurrency((Number(newValue) / LITERS_PER_GALLON), homeCurrency, localCurrency)
-    const newFormattedLocalPrice = getFormattedPrice(newLocalPrice)
+    const newValueAsNumber = Number(newValue.replaceAll(numberFormatChars.groupingSeparatorChar, ''))
+
+    const newLocalPrice = getPriceInCurrency(newValueAsNumber / LITERS_PER_GALLON, homeCurrency, localCurrency)
+    const newFormattedLocalPrice = getFormattedPrice(newLocalPrice, userLocale)
 
     setLocalPrice(newFormattedLocalPrice)
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,15 +31,33 @@ function App() {
     return Intl.NumberFormat('en-US', { style: 'currency', currency: localCurrency, currencyDisplay: 'code' }).format(price).replace(localCurrency, "").trim();
   }
 
-  const handleLocalPriceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.target.value;
-    const newChar = newValue?.slice(-1)
+  const isLegalPriceValue = (price: string) => {
+    // Generate a regular expression that confirms a character is legal for en-US formatting
+    const isLegalPriceChar = new RegExp(/[0-9\\.\\,]/);
 
+    // Is this something that someone logically type if they were writing a number out one character at a time?
+    // RegExp should allow values:
+    // - Any number of digits (including after the decimal point)
+    // - Any number of commas
+    // - Could start or end with a decimal point
+    // - Optionally, one decimal point
+    // - No commas allowed after the decimal point
+    const isLegalPrice = new RegExp(/^(\d{0,}(,\d{0,})*|\d*)?(\.\d*)?$/);
+
+    const newChar = price?.slice(-1)
     // If the new value is not "" and the new char is not a number, return
-    if (newValue && RegExp(/[0-9\\.]/).test(newChar) === false) return
+    if (price && isLegalPriceChar.test(newChar) === false) return false
 
     // If the new value is not a number, return
-    if (Number.isNaN(Number(newValue))) return
+    if (isLegalPrice.test(price) === false) return false
+
+    return true
+  }
+
+  const handleLocalPriceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value;
+
+    if (isLegalPriceValue(newValue) === false) return
 
     setLocalPrice(newValue);
 
@@ -51,13 +69,8 @@ function App() {
 
   const handleHomePriceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;
-    const newChar = newValue?.slice(-1)
 
-    // If the new value is not "" and the new char is not a number, return
-    if (newValue && RegExp(/[0-9\\.]/).test(newChar) === false) return
-
-    // If the new value is not a number, return
-    if (Number.isNaN(Number(newValue))) return
+    if (isLegalPriceValue(newValue) === false) return
 
     setHomePrice(newValue);
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,10 +3,13 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2023",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
-
     /* Bundler mode */
     "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
@@ -14,7 +17,6 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
-
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
@@ -22,5 +24,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
I updated the TS reference to ES2023 to get `replaceAll` (really shipped in ES2021 but w/e) but I'm not sure if there's some kind of "compile target library" that Vite compiles to. Like is this compiling down to ES5 or did I just declare all users must support ES2023?

Hot diggity dog!