### PR TITLE
:accessibility: feat: Clear input on focus when it shows 0.00

### DIFF
--- a/src/ConversionTable.test.tsx
+++ b/src/ConversionTable.test.tsx
@@ -70,7 +70,7 @@ describe("<ConversionTable />", () => {
 
         expect(
             screen.getByLabelText("Unit of measure conversion").textContent,
-        ).toContain('gallons per liter');
+        ).toContain('liters per gallon');
 
         expect(
             screen.getByLabelText("Currency conversion").textContent,

--- a/src/ConversionTable.tsx
+++ b/src/ConversionTable.tsx
@@ -58,7 +58,9 @@ const ConversionTable = ({
                     if I don't include it, it reads like "x 1gallons per gallon" */}
                     <td className="operation">{unitConversionFormula.operation} {unitConversionFormula.rate} </td>
                     {/* TODO: Use an Intl method to pluralize the source unit. Adding an "s" to pluralize the source unit is a bit of a hack */}
-                    <td className="operation-description">{sourceUnit}s per {targetUnit}</td>
+                    <td className="operation-description">
+                        {unitConversionFormula.operation === "÷" ? `${targetUnit}s per ${sourceUnit}` : `${sourceUnit}s per ${targetUnit}`}
+                    </td>
                 </tr>
                 <tr aria-label="Currency conversion">
                     {/* TODO: Look up what the best practice is for displaying a string across mulitple table cells. This trailing space feels hacky, but

--- a/src/GasPrice.test.tsx
+++ b/src/GasPrice.test.tsx
@@ -52,6 +52,16 @@ describe("<GasPrice />", () => {
     expect(input.value).toBe("123");
   });
 
+  test("clears the number input when the starting value is 0", async () => {
+    const input = screen.getByLabelText("Amount", {
+      exact: false,
+    }) as HTMLInputElement;
+
+    expect(input.value).toBe("0.00");
+    await user.click(input);
+    expect(input.value).toBe("");
+  });
+
   test("prevents the user from entering illegal characters", async () => {
     const input = screen.getByLabelText("Amount", {
       exact: false,

--- a/src/GasPrice.tsx
+++ b/src/GasPrice.tsx
@@ -62,6 +62,9 @@ function GasPrice({
         type="text"
         value={displayNumber}
         onFocus={() => {
+          if (displayNumber === "0.00") {
+            setDisplayNumber("")
+          }
           setIsNumberFocused(true);
         }}
         onBlur={() => {


### PR DESCRIPTION
Also fixes a bug where the unit conversion explanation was shown wrong