### PR TITLE
🧪 test: Add tests for getGasPrice and App behavior

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -16,7 +16,7 @@ describe("<App />", () => {
   )[0] as HTMLSelectElement;
   const topUnitInput = screen.getAllByLabelText(
     "Unit of sale", { selector: 'select', exact: false },
-  )[0] as HTMLButtonElement;
+  )[0] as HTMLSelectElement;
   const bottomPriceInput = screen.getAllByLabelText(
     "Amount", { selector: 'input', exact: false },
   )[1] as HTMLInputElement;
@@ -97,37 +97,40 @@ describe("<App />", () => {
     expect(bottomPriceInput.value).toBe("1,234.00");
   });
 
-  test("updates bottom price (but not top price) when the user updates the target currency or units", async () => {
-    // Clear the local price input
-    await userEvent.clear(topPriceInput);
+  test("updates bottom price (but not top price) when the user updates the bottom currency or units", async () => {
+    // Perform the setup; 6.78, BRL, liters
+    await user.click(topPriceInput);
     await user.keyboard("6.78");
-
     await selectItemFromCombobox(topCurrencyButton, "Brazilian Real (BRL)")
     await user.selectOptions(topUnitInput, "per liter");
 
+    // Expect all the top values are as expected
     expect(topPriceInput.value).toBe("6.78");
+    expect(topCurrencyButton.textContent).toBe("BRL");
+    expect(topUnitInput.options[topUnitInput.selectedIndex].text).toBe("per liter");
+
+    // Expect the bottom value got converted right
     expect(bottomPriceInput.value).toBe(getFormattedPrice(getGasPrice(6.78, "BRL", "liter", "USD", "gallon"), "en-US", "USD"));
 
+    // Expect the top input to stay the same while updating the bottom currency
     await selectItemFromCombobox(bottomCurrencyButton, "Brazilian Real (BRL)")
+    expect(topPriceInput.value).toBe("6.78");
     expect(bottomPriceInput.value).toBe(getFormattedPrice(getGasPrice(6.78, "BRL", "liter", "BRL", "gallon"), "en-US", "BRL"));
 
+    // Expect the top input to stay the same while updating the bottom volume measure
     await user.selectOptions(bottomUnitInput, "per liter");
-    expect(bottomPriceInput.value).toBe(getFormattedPrice(getGasPrice(6.78, "BRL", "liter", "BRL", "liter"), "en-US", "USD"));
-  });
+    expect(bottomPriceInput.value).toBe(getFormattedPrice(getGasPrice(6.78, "BRL", "liter", "BRL", "liter"), "en-US", "BRL"));
 
-  test("updates the top price when the user changes the bottom price", async () => {
-    await selectItemFromCombobox(topCurrencyButton, /BRL/)
-    await user.selectOptions(topUnitInput, "per liter");
-    await selectItemFromCombobox(bottomCurrencyButton, /USD/)
-    await user.selectOptions(bottomUnitInput, "per gallon");
-
-    // Set a home price;
+    // Expect the top price to change when changing the bottom price
     await user.click(bottomPriceInput);
     await user.clear(bottomPriceInput);
     await user.keyboard("4.43");
     expect(bottomPriceInput.value).toBe("4.43");
+    expect(topPriceInput.value).toBe(getFormattedPrice(getGasPrice(4.43, "BRL", "liter", "BRL", "liter"), "en-US", "BRL"));
 
-    // Expect the local price field to have a value based on the home price
-    expect(topPriceInput.value).toBe(getFormattedPrice(getGasPrice(4.43, "USD", "gallon", "BRL", "liter"), "en-US", "USD"));
+    // Expect the top price to change when updating the bottom currency
+    await selectItemFromCombobox(bottomCurrencyButton, /USD/)
+    await user.selectOptions(bottomUnitInput, "per gallon")
+    expect(topPriceInput.value).toBe(getFormattedPrice(getGasPrice(4.43, "USD", "gallon", "BRL", "liter"), "en-US", "BRL"));
   });
 });

--- a/src/getGasPrice.test.ts
+++ b/src/getGasPrice.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect } from "vitest";
+import getGasPrice from "./utils/getGasPrice";
+
+describe("getGasPrice method", () => {
+  const fakeExchangeRates = {
+    BRL: 5,
+    EUR: 1,
+    USD: 1,
+  };
+
+  test("can handle a 1:5 exchange rate", () => {
+    const result = getGasPrice(
+      100,
+      "USD",
+      "gallon",
+      "BRL",
+      "gallon",
+      fakeExchangeRates,
+    );
+
+    expect(result).toBe(500);
+  });
+
+  test("can handle a 5:1 exchange rate", () => {
+    const result = getGasPrice(
+      500,
+      "BRL",
+      "gallon",
+      "USD",
+      "gallon",
+      fakeExchangeRates,
+    );
+
+    expect(result).toBe(100);
+  });
+
+  test("can handle a 1:1 exchange rate", () => {
+    const result = getGasPrice(
+      100,
+      "USD",
+      "gallon",
+      "USD",
+      "gallon",
+      fakeExchangeRates,
+    );
+
+    expect(result).toBe(100);
+  });
+
+  test("can handle a 5:5 exchange rate", () => {
+    const result = getGasPrice(
+      100,
+      "BRL",
+      "gallon",
+      "BRL",
+      "gallon",
+      fakeExchangeRates,
+    );
+
+    expect(result).toBe(100);
+  });
+
+  test("can convert a price in liters to a price in gallons", () => {
+    const result = getGasPrice(
+      1,
+      "BRL",
+      "liter",
+      "BRL",
+      "gallon",
+      fakeExchangeRates,
+    );
+
+    expect(result).toBe(3.78541);
+  });
+
+  test("can do no-op conversions", () => {
+    const result = getGasPrice(
+      1,
+      "BRL",
+      "gallon",
+      "BRL",
+      "gallon",
+      fakeExchangeRates,
+    );
+
+    expect(result).toBe(1);
+  });
+
+  test("can convert a price in gallons to a price in liters", () => {
+    const result = getGasPrice(
+      3.78541,
+      "BRL",
+      "gallon",
+      "BRL",
+      "liter",
+      fakeExchangeRates,
+    );
+
+    expect(result).toBe(1);
+  });
+
+  test("can convert currencies and volumes simultaneously", () => {
+    const result = getGasPrice(
+      3.78541,
+      "USD",
+      "gallon",
+      "BRL",
+      "liter",
+      fakeExchangeRates,
+    );
+
+    expect(result).toBe(5);
+  });
+
+  test("can do a no-op currency conversion and normal volume conversion", () => {
+    const result = getGasPrice(
+      3.78541,
+      "USD",
+      "gallon",
+      "EUR",
+      "liter",
+      fakeExchangeRates,
+    );
+
+    expect(result).toBe(1);
+  });
+});

--- a/src/utils/getGasPrice.ts
+++ b/src/utils/getGasPrice.ts
@@ -6,8 +6,8 @@ const getPriceInCurrency = (
   price: number,
   currency: string,
   targetCurrency: string,
+  exchangeRates: { [key: string]: number } = exchangeRateData.rates,
 ) => {
-  const exchangeRates = exchangeRateData.rates as { [key: string]: number };
   const sourceCurrencyExchangeRate = exchangeRates[currency] ?? 1;
   const targetCurrencyExchangeRate = exchangeRates[targetCurrency] ?? 1;
   let newValue = 0;
@@ -28,12 +28,18 @@ const getGasPrice = (
   sourceUnit: SupportedUnits,
   targetCurrency: string,
   targetUnit: SupportedUnits,
+  exchangeRates?: { [key: string]: number },
 ) => {
   // Convert that number from using source units to target units
   let result = getUnits(sourceNumber, sourceUnit, targetUnit);
 
   // Convert _that_ number using the exchange rate from source currency to target currency
-  result = getPriceInCurrency(result, sourceCurrency, targetCurrency);
+  result = getPriceInCurrency(
+    result,
+    sourceCurrency,
+    targetCurrency,
+    exchangeRates,
+  );
 
   return result;
 };


### PR DESCRIPTION
The app is built on calculating gas prices correctly!

Also the behavior for keeping one field's value the same while updating the other is a little tricky.

These tests may catch issues when I do my inevitable refactoring.