### PR TITLE
🐛 fix: Fix depth warning

### DIFF
--- a/public/currencies.json
+++ b/public/currencies.json
@@ -1,3 +1,1022 @@
-{
-  "this": [ "file", "is", "not", "in", "use"]  
-}
+[
+  {
+      "value": "AED",
+      "label": "United Arab Emirates Dirham (AED)",
+      "children": "United Arab Emirates Dirham (AED)",
+      "id": "United Arab Emirates Dirham (AED)"
+  },
+  {
+      "value": "AFN",
+      "label": "Afghan Afghani (AFN)",
+      "children": "Afghan Afghani (AFN)",
+      "id": "Afghan Afghani (AFN)"
+  },
+  {
+      "value": "ALL",
+      "label": "Albanian Lek (ALL)",
+      "children": "Albanian Lek (ALL)",
+      "id": "Albanian Lek (ALL)"
+  },
+  {
+      "value": "AMD",
+      "label": "Armenian Dram (AMD)",
+      "children": "Armenian Dram (AMD)",
+      "id": "Armenian Dram (AMD)"
+  },
+  {
+      "value": "ANG",
+      "label": "Netherlands Antillean Guilder (ANG)",
+      "children": "Netherlands Antillean Guilder (ANG)",
+      "id": "Netherlands Antillean Guilder (ANG)"
+  },
+  {
+      "value": "AOA",
+      "label": "Angolan Kwanza (AOA)",
+      "children": "Angolan Kwanza (AOA)",
+      "id": "Angolan Kwanza (AOA)"
+  },
+  {
+      "value": "ARS",
+      "label": "Argentine Peso (ARS)",
+      "children": "Argentine Peso (ARS)",
+      "id": "Argentine Peso (ARS)"
+  },
+  {
+      "value": "AUD",
+      "label": "Australian Dollar (AUD)",
+      "children": "Australian Dollar (AUD)",
+      "id": "Australian Dollar (AUD)"
+  },
+  {
+      "value": "AWG",
+      "label": "Aruban Florin (AWG)",
+      "children": "Aruban Florin (AWG)",
+      "id": "Aruban Florin (AWG)"
+  },
+  {
+      "value": "AZN",
+      "label": "Azerbaijani Manat (AZN)",
+      "children": "Azerbaijani Manat (AZN)",
+      "id": "Azerbaijani Manat (AZN)"
+  },
+  {
+      "value": "BAM",
+      "label": "Bosnia-Herzegovina Convertible Mark (BAM)",
+      "children": "Bosnia-Herzegovina Convertible Mark (BAM)",
+      "id": "Bosnia-Herzegovina Convertible Mark (BAM)"
+  },
+  {
+      "value": "BBD",
+      "label": "Barbadian Dollar (BBD)",
+      "children": "Barbadian Dollar (BBD)",
+      "id": "Barbadian Dollar (BBD)"
+  },
+  {
+      "value": "BDT",
+      "label": "Bangladeshi Taka (BDT)",
+      "children": "Bangladeshi Taka (BDT)",
+      "id": "Bangladeshi Taka (BDT)"
+  },
+  {
+      "value": "BGN",
+      "label": "Bulgarian Lev (BGN)",
+      "children": "Bulgarian Lev (BGN)",
+      "id": "Bulgarian Lev (BGN)"
+  },
+  {
+      "value": "BHD",
+      "label": "Bahraini Dinar (BHD)",
+      "children": "Bahraini Dinar (BHD)",
+      "id": "Bahraini Dinar (BHD)"
+  },
+  {
+      "value": "BIF",
+      "label": "Burundian Franc (BIF)",
+      "children": "Burundian Franc (BIF)",
+      "id": "Burundian Franc (BIF)"
+  },
+  {
+      "value": "BMD",
+      "label": "Bermudan Dollar (BMD)",
+      "children": "Bermudan Dollar (BMD)",
+      "id": "Bermudan Dollar (BMD)"
+  },
+  {
+      "value": "BND",
+      "label": "Brunei Dollar (BND)",
+      "children": "Brunei Dollar (BND)",
+      "id": "Brunei Dollar (BND)"
+  },
+  {
+      "value": "BOB",
+      "label": "Bolivian Boliviano (BOB)",
+      "children": "Bolivian Boliviano (BOB)",
+      "id": "Bolivian Boliviano (BOB)"
+  },
+  {
+      "value": "BRL",
+      "label": "Brazilian Real (BRL)",
+      "children": "Brazilian Real (BRL)",
+      "id": "Brazilian Real (BRL)"
+  },
+  {
+      "value": "BSD",
+      "label": "Bahamian Dollar (BSD)",
+      "children": "Bahamian Dollar (BSD)",
+      "id": "Bahamian Dollar (BSD)"
+  },
+  {
+      "value": "BTC",
+      "label": "Bitcoin (BTC)",
+      "children": "Bitcoin (BTC)",
+      "id": "Bitcoin (BTC)"
+  },
+  {
+      "value": "BTN",
+      "label": "Bhutanese Ngultrum (BTN)",
+      "children": "Bhutanese Ngultrum (BTN)",
+      "id": "Bhutanese Ngultrum (BTN)"
+  },
+  {
+      "value": "BWP",
+      "label": "Botswanan Pula (BWP)",
+      "children": "Botswanan Pula (BWP)",
+      "id": "Botswanan Pula (BWP)"
+  },
+  {
+      "value": "BYN",
+      "label": "New Belarusian Ruble (BYN)",
+      "children": "New Belarusian Ruble (BYN)",
+      "id": "New Belarusian Ruble (BYN)"
+  },
+  {
+      "value": "BYR",
+      "label": "Belarusian Ruble (BYR)",
+      "children": "Belarusian Ruble (BYR)",
+      "id": "Belarusian Ruble (BYR)"
+  },
+  {
+      "value": "BZD",
+      "label": "Belize Dollar (BZD)",
+      "children": "Belize Dollar (BZD)",
+      "id": "Belize Dollar (BZD)"
+  },
+  {
+      "value": "CAD",
+      "label": "Canadian Dollar (CAD)",
+      "children": "Canadian Dollar (CAD)",
+      "id": "Canadian Dollar (CAD)"
+  },
+  {
+      "value": "CDF",
+      "label": "Congolese Franc (CDF)",
+      "children": "Congolese Franc (CDF)",
+      "id": "Congolese Franc (CDF)"
+  },
+  {
+      "value": "CHF",
+      "label": "Swiss Franc (CHF)",
+      "children": "Swiss Franc (CHF)",
+      "id": "Swiss Franc (CHF)"
+  },
+  {
+      "value": "CLF",
+      "label": "Chilean Unit of Account (UF) (CLF)",
+      "children": "Chilean Unit of Account (UF) (CLF)",
+      "id": "Chilean Unit of Account (UF) (CLF)"
+  },
+  {
+      "value": "CLP",
+      "label": "Chilean Peso (CLP)",
+      "children": "Chilean Peso (CLP)",
+      "id": "Chilean Peso (CLP)"
+  },
+  {
+      "value": "CNY",
+      "label": "Chinese Yuan (CNY)",
+      "children": "Chinese Yuan (CNY)",
+      "id": "Chinese Yuan (CNY)"
+  },
+  {
+      "value": "CNH",
+      "label": "Chinese Yuan Offshore (CNH)",
+      "children": "Chinese Yuan Offshore (CNH)",
+      "id": "Chinese Yuan Offshore (CNH)"
+  },
+  {
+      "value": "COP",
+      "label": "Colombian Peso (COP)",
+      "children": "Colombian Peso (COP)",
+      "id": "Colombian Peso (COP)"
+  },
+  {
+      "value": "CRC",
+      "label": "Costa Rican Colón (CRC)",
+      "children": "Costa Rican Colón (CRC)",
+      "id": "Costa Rican Colón (CRC)"
+  },
+  {
+      "value": "CUC",
+      "label": "Cuban Convertible Peso (CUC)",
+      "children": "Cuban Convertible Peso (CUC)",
+      "id": "Cuban Convertible Peso (CUC)"
+  },
+  {
+      "value": "CUP",
+      "label": "Cuban Peso (CUP)",
+      "children": "Cuban Peso (CUP)",
+      "id": "Cuban Peso (CUP)"
+  },
+  {
+      "value": "CVE",
+      "label": "Cape Verdean Escudo (CVE)",
+      "children": "Cape Verdean Escudo (CVE)",
+      "id": "Cape Verdean Escudo (CVE)"
+  },
+  {
+      "value": "CZK",
+      "label": "Czech Republic Koruna (CZK)",
+      "children": "Czech Republic Koruna (CZK)",
+      "id": "Czech Republic Koruna (CZK)"
+  },
+  {
+      "value": "DJF",
+      "label": "Djiboutian Franc (DJF)",
+      "children": "Djiboutian Franc (DJF)",
+      "id": "Djiboutian Franc (DJF)"
+  },
+  {
+      "value": "DKK",
+      "label": "Danish Krone (DKK)",
+      "children": "Danish Krone (DKK)",
+      "id": "Danish Krone (DKK)"
+  },
+  {
+      "value": "DOP",
+      "label": "Dominican Peso (DOP)",
+      "children": "Dominican Peso (DOP)",
+      "id": "Dominican Peso (DOP)"
+  },
+  {
+      "value": "DZD",
+      "label": "Algerian Dinar (DZD)",
+      "children": "Algerian Dinar (DZD)",
+      "id": "Algerian Dinar (DZD)"
+  },
+  {
+      "value": "EGP",
+      "label": "Egyptian Pound (EGP)",
+      "children": "Egyptian Pound (EGP)",
+      "id": "Egyptian Pound (EGP)"
+  },
+  {
+      "value": "ERN",
+      "label": "Eritrean Nakfa (ERN)",
+      "children": "Eritrean Nakfa (ERN)",
+      "id": "Eritrean Nakfa (ERN)"
+  },
+  {
+      "value": "ETB",
+      "label": "Ethiopian Birr (ETB)",
+      "children": "Ethiopian Birr (ETB)",
+      "id": "Ethiopian Birr (ETB)"
+  },
+  {
+      "value": "EUR",
+      "label": "Euro (EUR)",
+      "children": "Euro (EUR)",
+      "id": "Euro (EUR)"
+  },
+  {
+      "value": "FJD",
+      "label": "Fijian Dollar (FJD)",
+      "children": "Fijian Dollar (FJD)",
+      "id": "Fijian Dollar (FJD)"
+  },
+  {
+      "value": "FKP",
+      "label": "Falkland Islands Pound (FKP)",
+      "children": "Falkland Islands Pound (FKP)",
+      "id": "Falkland Islands Pound (FKP)"
+  },
+  {
+      "value": "GBP",
+      "label": "British Pound Sterling (GBP)",
+      "children": "British Pound Sterling (GBP)",
+      "id": "British Pound Sterling (GBP)"
+  },
+  {
+      "value": "GEL",
+      "label": "Georgian Lari (GEL)",
+      "children": "Georgian Lari (GEL)",
+      "id": "Georgian Lari (GEL)"
+  },
+  {
+      "value": "GGP",
+      "label": "Guernsey Pound (GGP)",
+      "children": "Guernsey Pound (GGP)",
+      "id": "Guernsey Pound (GGP)"
+  },
+  {
+      "value": "GHS",
+      "label": "Ghanaian Cedi (GHS)",
+      "children": "Ghanaian Cedi (GHS)",
+      "id": "Ghanaian Cedi (GHS)"
+  },
+  {
+      "value": "GIP",
+      "label": "Gibraltar Pound (GIP)",
+      "children": "Gibraltar Pound (GIP)",
+      "id": "Gibraltar Pound (GIP)"
+  },
+  {
+      "value": "GMD",
+      "label": "Gambian Dalasi (GMD)",
+      "children": "Gambian Dalasi (GMD)",
+      "id": "Gambian Dalasi (GMD)"
+  },
+  {
+      "value": "GNF",
+      "label": "Guinean Franc (GNF)",
+      "children": "Guinean Franc (GNF)",
+      "id": "Guinean Franc (GNF)"
+  },
+  {
+      "value": "GTQ",
+      "label": "Guatemalan Quetzal (GTQ)",
+      "children": "Guatemalan Quetzal (GTQ)",
+      "id": "Guatemalan Quetzal (GTQ)"
+  },
+  {
+      "value": "GYD",
+      "label": "Guyanaese Dollar (GYD)",
+      "children": "Guyanaese Dollar (GYD)",
+      "id": "Guyanaese Dollar (GYD)"
+  },
+  {
+      "value": "HKD",
+      "label": "Hong Kong Dollar (HKD)",
+      "children": "Hong Kong Dollar (HKD)",
+      "id": "Hong Kong Dollar (HKD)"
+  },
+  {
+      "value": "HNL",
+      "label": "Honduran Lempira (HNL)",
+      "children": "Honduran Lempira (HNL)",
+      "id": "Honduran Lempira (HNL)"
+  },
+  {
+      "value": "HRK",
+      "label": "Croatian Kuna (HRK)",
+      "children": "Croatian Kuna (HRK)",
+      "id": "Croatian Kuna (HRK)"
+  },
+  {
+      "value": "HTG",
+      "label": "Haitian Gourde (HTG)",
+      "children": "Haitian Gourde (HTG)",
+      "id": "Haitian Gourde (HTG)"
+  },
+  {
+      "value": "HUF",
+      "label": "Hungarian Forint (HUF)",
+      "children": "Hungarian Forint (HUF)",
+      "id": "Hungarian Forint (HUF)"
+  },
+  {
+      "value": "IDR",
+      "label": "Indonesian Rupiah (IDR)",
+      "children": "Indonesian Rupiah (IDR)",
+      "id": "Indonesian Rupiah (IDR)"
+  },
+  {
+      "value": "ILS",
+      "label": "Israeli New Sheqel (ILS)",
+      "children": "Israeli New Sheqel (ILS)",
+      "id": "Israeli New Sheqel (ILS)"
+  },
+  {
+      "value": "IMP",
+      "label": "Manx pound (IMP)",
+      "children": "Manx pound (IMP)",
+      "id": "Manx pound (IMP)"
+  },
+  {
+      "value": "INR",
+      "label": "Indian Rupee (INR)",
+      "children": "Indian Rupee (INR)",
+      "id": "Indian Rupee (INR)"
+  },
+  {
+      "value": "IQD",
+      "label": "Iraqi Dinar (IQD)",
+      "children": "Iraqi Dinar (IQD)",
+      "id": "Iraqi Dinar (IQD)"
+  },
+  {
+      "value": "IRR",
+      "label": "Iranian Rial (IRR)",
+      "children": "Iranian Rial (IRR)",
+      "id": "Iranian Rial (IRR)"
+  },
+  {
+      "value": "ISK",
+      "label": "Icelandic Króna (ISK)",
+      "children": "Icelandic Króna (ISK)",
+      "id": "Icelandic Króna (ISK)"
+  },
+  {
+      "value": "JEP",
+      "label": "Jersey Pound (JEP)",
+      "children": "Jersey Pound (JEP)",
+      "id": "Jersey Pound (JEP)"
+  },
+  {
+      "value": "JMD",
+      "label": "Jamaican Dollar (JMD)",
+      "children": "Jamaican Dollar (JMD)",
+      "id": "Jamaican Dollar (JMD)"
+  },
+  {
+      "value": "JOD",
+      "label": "Jordanian Dinar (JOD)",
+      "children": "Jordanian Dinar (JOD)",
+      "id": "Jordanian Dinar (JOD)"
+  },
+  {
+      "value": "JPY",
+      "label": "Japanese Yen (JPY)",
+      "children": "Japanese Yen (JPY)",
+      "id": "Japanese Yen (JPY)"
+  },
+  {
+      "value": "KES",
+      "label": "Kenyan Shilling (KES)",
+      "children": "Kenyan Shilling (KES)",
+      "id": "Kenyan Shilling (KES)"
+  },
+  {
+      "value": "KGS",
+      "label": "Kyrgystani Som (KGS)",
+      "children": "Kyrgystani Som (KGS)",
+      "id": "Kyrgystani Som (KGS)"
+  },
+  {
+      "value": "KHR",
+      "label": "Cambodian Riel (KHR)",
+      "children": "Cambodian Riel (KHR)",
+      "id": "Cambodian Riel (KHR)"
+  },
+  {
+      "value": "KMF",
+      "label": "Comorian Franc (KMF)",
+      "children": "Comorian Franc (KMF)",
+      "id": "Comorian Franc (KMF)"
+  },
+  {
+      "value": "KPW",
+      "label": "North Korean Won (KPW)",
+      "children": "North Korean Won (KPW)",
+      "id": "North Korean Won (KPW)"
+  },
+  {
+      "value": "KRW",
+      "label": "South Korean Won (KRW)",
+      "children": "South Korean Won (KRW)",
+      "id": "South Korean Won (KRW)"
+  },
+  {
+      "value": "KWD",
+      "label": "Kuwaiti Dinar (KWD)",
+      "children": "Kuwaiti Dinar (KWD)",
+      "id": "Kuwaiti Dinar (KWD)"
+  },
+  {
+      "value": "KYD",
+      "label": "Cayman Islands Dollar (KYD)",
+      "children": "Cayman Islands Dollar (KYD)",
+      "id": "Cayman Islands Dollar (KYD)"
+  },
+  {
+      "value": "KZT",
+      "label": "Kazakhstani Tenge (KZT)",
+      "children": "Kazakhstani Tenge (KZT)",
+      "id": "Kazakhstani Tenge (KZT)"
+  },
+  {
+      "value": "LAK",
+      "label": "Laotian Kip (LAK)",
+      "children": "Laotian Kip (LAK)",
+      "id": "Laotian Kip (LAK)"
+  },
+  {
+      "value": "LBP",
+      "label": "Lebanese Pound (LBP)",
+      "children": "Lebanese Pound (LBP)",
+      "id": "Lebanese Pound (LBP)"
+  },
+  {
+      "value": "LKR",
+      "label": "Sri Lankan Rupee (LKR)",
+      "children": "Sri Lankan Rupee (LKR)",
+      "id": "Sri Lankan Rupee (LKR)"
+  },
+  {
+      "value": "LRD",
+      "label": "Liberian Dollar (LRD)",
+      "children": "Liberian Dollar (LRD)",
+      "id": "Liberian Dollar (LRD)"
+  },
+  {
+      "value": "LSL",
+      "label": "Lesotho Loti (LSL)",
+      "children": "Lesotho Loti (LSL)",
+      "id": "Lesotho Loti (LSL)"
+  },
+  {
+      "value": "LTL",
+      "label": "Lithuanian Litas (LTL)",
+      "children": "Lithuanian Litas (LTL)",
+      "id": "Lithuanian Litas (LTL)"
+  },
+  {
+      "value": "LVL",
+      "label": "Latvian Lats (LVL)",
+      "children": "Latvian Lats (LVL)",
+      "id": "Latvian Lats (LVL)"
+  },
+  {
+      "value": "LYD",
+      "label": "Libyan Dinar (LYD)",
+      "children": "Libyan Dinar (LYD)",
+      "id": "Libyan Dinar (LYD)"
+  },
+  {
+      "value": "MAD",
+      "label": "Moroccan Dirham (MAD)",
+      "children": "Moroccan Dirham (MAD)",
+      "id": "Moroccan Dirham (MAD)"
+  },
+  {
+      "value": "MDL",
+      "label": "Moldovan Leu (MDL)",
+      "children": "Moldovan Leu (MDL)",
+      "id": "Moldovan Leu (MDL)"
+  },
+  {
+      "value": "MGA",
+      "label": "Malagasy Ariary (MGA)",
+      "children": "Malagasy Ariary (MGA)",
+      "id": "Malagasy Ariary (MGA)"
+  },
+  {
+      "value": "MKD",
+      "label": "Macedonian Denar (MKD)",
+      "children": "Macedonian Denar (MKD)",
+      "id": "Macedonian Denar (MKD)"
+  },
+  {
+      "value": "MMK",
+      "label": "Myanma Kyat (MMK)",
+      "children": "Myanma Kyat (MMK)",
+      "id": "Myanma Kyat (MMK)"
+  },
+  {
+      "value": "MNT",
+      "label": "Mongolian Tugrik (MNT)",
+      "children": "Mongolian Tugrik (MNT)",
+      "id": "Mongolian Tugrik (MNT)"
+  },
+  {
+      "value": "MOP",
+      "label": "Macanese Pataca (MOP)",
+      "children": "Macanese Pataca (MOP)",
+      "id": "Macanese Pataca (MOP)"
+  },
+  {
+      "value": "MRU",
+      "label": "Mauritanian Ouguiya (MRU)",
+      "children": "Mauritanian Ouguiya (MRU)",
+      "id": "Mauritanian Ouguiya (MRU)"
+  },
+  {
+      "value": "MUR",
+      "label": "Mauritian Rupee (MUR)",
+      "children": "Mauritian Rupee (MUR)",
+      "id": "Mauritian Rupee (MUR)"
+  },
+  {
+      "value": "MVR",
+      "label": "Maldivian Rufiyaa (MVR)",
+      "children": "Maldivian Rufiyaa (MVR)",
+      "id": "Maldivian Rufiyaa (MVR)"
+  },
+  {
+      "value": "MWK",
+      "label": "Malawian Kwacha (MWK)",
+      "children": "Malawian Kwacha (MWK)",
+      "id": "Malawian Kwacha (MWK)"
+  },
+  {
+      "value": "MXN",
+      "label": "Mexican Peso (MXN)",
+      "children": "Mexican Peso (MXN)",
+      "id": "Mexican Peso (MXN)"
+  },
+  {
+      "value": "MYR",
+      "label": "Malaysian Ringgit (MYR)",
+      "children": "Malaysian Ringgit (MYR)",
+      "id": "Malaysian Ringgit (MYR)"
+  },
+  {
+      "value": "MZN",
+      "label": "Mozambican Metical (MZN)",
+      "children": "Mozambican Metical (MZN)",
+      "id": "Mozambican Metical (MZN)"
+  },
+  {
+      "value": "NAD",
+      "label": "Namibian Dollar (NAD)",
+      "children": "Namibian Dollar (NAD)",
+      "id": "Namibian Dollar (NAD)"
+  },
+  {
+      "value": "NGN",
+      "label": "Nigerian Naira (NGN)",
+      "children": "Nigerian Naira (NGN)",
+      "id": "Nigerian Naira (NGN)"
+  },
+  {
+      "value": "NIO",
+      "label": "Nicaraguan Córdoba (NIO)",
+      "children": "Nicaraguan Córdoba (NIO)",
+      "id": "Nicaraguan Córdoba (NIO)"
+  },
+  {
+      "value": "NOK",
+      "label": "Norwegian Krone (NOK)",
+      "children": "Norwegian Krone (NOK)",
+      "id": "Norwegian Krone (NOK)"
+  },
+  {
+      "value": "NPR",
+      "label": "Nepalese Rupee (NPR)",
+      "children": "Nepalese Rupee (NPR)",
+      "id": "Nepalese Rupee (NPR)"
+  },
+  {
+      "value": "NZD",
+      "label": "New Zealand Dollar (NZD)",
+      "children": "New Zealand Dollar (NZD)",
+      "id": "New Zealand Dollar (NZD)"
+  },
+  {
+      "value": "OMR",
+      "label": "Omani Rial (OMR)",
+      "children": "Omani Rial (OMR)",
+      "id": "Omani Rial (OMR)"
+  },
+  {
+      "value": "PAB",
+      "label": "Panamanian Balboa (PAB)",
+      "children": "Panamanian Balboa (PAB)",
+      "id": "Panamanian Balboa (PAB)"
+  },
+  {
+      "value": "PEN",
+      "label": "Peruvian Nuevo Sol (PEN)",
+      "children": "Peruvian Nuevo Sol (PEN)",
+      "id": "Peruvian Nuevo Sol (PEN)"
+  },
+  {
+      "value": "PGK",
+      "label": "Papua New Guinean Kina (PGK)",
+      "children": "Papua New Guinean Kina (PGK)",
+      "id": "Papua New Guinean Kina (PGK)"
+  },
+  {
+      "value": "PHP",
+      "label": "Philippine Peso (PHP)",
+      "children": "Philippine Peso (PHP)",
+      "id": "Philippine Peso (PHP)"
+  },
+  {
+      "value": "PKR",
+      "label": "Pakistani Rupee (PKR)",
+      "children": "Pakistani Rupee (PKR)",
+      "id": "Pakistani Rupee (PKR)"
+  },
+  {
+      "value": "PLN",
+      "label": "Polish Zloty (PLN)",
+      "children": "Polish Zloty (PLN)",
+      "id": "Polish Zloty (PLN)"
+  },
+  {
+      "value": "PYG",
+      "label": "Paraguayan Guarani (PYG)",
+      "children": "Paraguayan Guarani (PYG)",
+      "id": "Paraguayan Guarani (PYG)"
+  },
+  {
+      "value": "QAR",
+      "label": "Qatari Rial (QAR)",
+      "children": "Qatari Rial (QAR)",
+      "id": "Qatari Rial (QAR)"
+  },
+  {
+      "value": "RON",
+      "label": "Romanian Leu (RON)",
+      "children": "Romanian Leu (RON)",
+      "id": "Romanian Leu (RON)"
+  },
+  {
+      "value": "RSD",
+      "label": "Serbian Dinar (RSD)",
+      "children": "Serbian Dinar (RSD)",
+      "id": "Serbian Dinar (RSD)"
+  },
+  {
+      "value": "RUB",
+      "label": "Russian Ruble (RUB)",
+      "children": "Russian Ruble (RUB)",
+      "id": "Russian Ruble (RUB)"
+  },
+  {
+      "value": "RWF",
+      "label": "Rwandan Franc (RWF)",
+      "children": "Rwandan Franc (RWF)",
+      "id": "Rwandan Franc (RWF)"
+  },
+  {
+      "value": "SAR",
+      "label": "Saudi Riyal (SAR)",
+      "children": "Saudi Riyal (SAR)",
+      "id": "Saudi Riyal (SAR)"
+  },
+  {
+      "value": "SBD",
+      "label": "Solomon Islands Dollar (SBD)",
+      "children": "Solomon Islands Dollar (SBD)",
+      "id": "Solomon Islands Dollar (SBD)"
+  },
+  {
+      "value": "SCR",
+      "label": "Seychellois Rupee (SCR)",
+      "children": "Seychellois Rupee (SCR)",
+      "id": "Seychellois Rupee (SCR)"
+  },
+  {
+      "value": "SDG",
+      "label": "South Sudanese Pound (SDG)",
+      "children": "South Sudanese Pound (SDG)",
+      "id": "South Sudanese Pound (SDG)"
+  },
+  {
+      "value": "SEK",
+      "label": "Swedish Krona (SEK)",
+      "children": "Swedish Krona (SEK)",
+      "id": "Swedish Krona (SEK)"
+  },
+  {
+      "value": "SGD",
+      "label": "Singapore Dollar (SGD)",
+      "children": "Singapore Dollar (SGD)",
+      "id": "Singapore Dollar (SGD)"
+  },
+  {
+      "value": "SHP",
+      "label": "Saint Helena Pound (SHP)",
+      "children": "Saint Helena Pound (SHP)",
+      "id": "Saint Helena Pound (SHP)"
+  },
+  {
+      "value": "SLE",
+      "label": "Sierra Leonean Leone (SLE)",
+      "children": "Sierra Leonean Leone (SLE)",
+      "id": "Sierra Leonean Leone (SLE)"
+  },
+  {
+      "value": "SLL",
+      "label": "Sierra Leonean Leone (SLL)",
+      "children": "Sierra Leonean Leone (SLL)",
+      "id": "Sierra Leonean Leone (SLL)"
+  },
+  {
+      "value": "SOS",
+      "label": "Somali Shilling (SOS)",
+      "children": "Somali Shilling (SOS)",
+      "id": "Somali Shilling (SOS)"
+  },
+  {
+      "value": "SRD",
+      "label": "Surinamese Dollar (SRD)",
+      "children": "Surinamese Dollar (SRD)",
+      "id": "Surinamese Dollar (SRD)"
+  },
+  {
+      "value": "STD",
+      "label": "São Tomé and Príncipe Dobra (STD)",
+      "children": "São Tomé and Príncipe Dobra (STD)",
+      "id": "São Tomé and Príncipe Dobra (STD)"
+  },
+  {
+      "value": "SVC",
+      "label": "Salvadoran Colón (SVC)",
+      "children": "Salvadoran Colón (SVC)",
+      "id": "Salvadoran Colón (SVC)"
+  },
+  {
+      "value": "SYP",
+      "label": "Syrian Pound (SYP)",
+      "children": "Syrian Pound (SYP)",
+      "id": "Syrian Pound (SYP)"
+  },
+  {
+      "value": "SZL",
+      "label": "Swazi Lilangeni (SZL)",
+      "children": "Swazi Lilangeni (SZL)",
+      "id": "Swazi Lilangeni (SZL)"
+  },
+  {
+      "value": "THB",
+      "label": "Thai Baht (THB)",
+      "children": "Thai Baht (THB)",
+      "id": "Thai Baht (THB)"
+  },
+  {
+      "value": "TJS",
+      "label": "Tajikistani Somoni (TJS)",
+      "children": "Tajikistani Somoni (TJS)",
+      "id": "Tajikistani Somoni (TJS)"
+  },
+  {
+      "value": "TMT",
+      "label": "Turkmenistani Manat (TMT)",
+      "children": "Turkmenistani Manat (TMT)",
+      "id": "Turkmenistani Manat (TMT)"
+  },
+  {
+      "value": "TND",
+      "label": "Tunisian Dinar (TND)",
+      "children": "Tunisian Dinar (TND)",
+      "id": "Tunisian Dinar (TND)"
+  },
+  {
+      "value": "TOP",
+      "label": "Tongan Paʻanga (TOP)",
+      "children": "Tongan Paʻanga (TOP)",
+      "id": "Tongan Paʻanga (TOP)"
+  },
+  {
+      "value": "TRY",
+      "label": "Turkish Lira (TRY)",
+      "children": "Turkish Lira (TRY)",
+      "id": "Turkish Lira (TRY)"
+  },
+  {
+      "value": "TTD",
+      "label": "Trinidad and Tobago Dollar (TTD)",
+      "children": "Trinidad and Tobago Dollar (TTD)",
+      "id": "Trinidad and Tobago Dollar (TTD)"
+  },
+  {
+      "value": "TWD",
+      "label": "New Taiwan Dollar (TWD)",
+      "children": "New Taiwan Dollar (TWD)",
+      "id": "New Taiwan Dollar (TWD)"
+  },
+  {
+      "value": "TZS",
+      "label": "Tanzanian Shilling (TZS)",
+      "children": "Tanzanian Shilling (TZS)",
+      "id": "Tanzanian Shilling (TZS)"
+  },
+  {
+      "value": "UAH",
+      "label": "Ukrainian Hryvnia (UAH)",
+      "children": "Ukrainian Hryvnia (UAH)",
+      "id": "Ukrainian Hryvnia (UAH)"
+  },
+  {
+      "value": "UGX",
+      "label": "Ugandan Shilling (UGX)",
+      "children": "Ugandan Shilling (UGX)",
+      "id": "Ugandan Shilling (UGX)"
+  },
+  {
+      "value": "USD",
+      "label": "United States Dollar (USD)",
+      "children": "United States Dollar (USD)",
+      "id": "United States Dollar (USD)"
+  },
+  {
+      "value": "UYU",
+      "label": "Uruguayan Peso (UYU)",
+      "children": "Uruguayan Peso (UYU)",
+      "id": "Uruguayan Peso (UYU)"
+  },
+  {
+      "value": "UZS",
+      "label": "Uzbekistan Som (UZS)",
+      "children": "Uzbekistan Som (UZS)",
+      "id": "Uzbekistan Som (UZS)"
+  },
+  {
+      "value": "VES",
+      "label": "Sovereign Bolivar (VES)",
+      "children": "Sovereign Bolivar (VES)",
+      "id": "Sovereign Bolivar (VES)"
+  },
+  {
+      "value": "VND",
+      "label": "Vietnamese Dong (VND)",
+      "children": "Vietnamese Dong (VND)",
+      "id": "Vietnamese Dong (VND)"
+  },
+  {
+      "value": "VUV",
+      "label": "Vanuatu Vatu (VUV)",
+      "children": "Vanuatu Vatu (VUV)",
+      "id": "Vanuatu Vatu (VUV)"
+  },
+  {
+      "value": "WST",
+      "label": "Samoan Tala (WST)",
+      "children": "Samoan Tala (WST)",
+      "id": "Samoan Tala (WST)"
+  },
+  {
+      "value": "XAF",
+      "label": "CFA Franc BEAC (XAF)",
+      "children": "CFA Franc BEAC (XAF)",
+      "id": "CFA Franc BEAC (XAF)"
+  },
+  {
+      "value": "XAG",
+      "label": "Silver (troy ounce) (XAG)",
+      "children": "Silver (troy ounce) (XAG)",
+      "id": "Silver (troy ounce) (XAG)"
+  },
+  {
+      "value": "XAU",
+      "label": "Gold (troy ounce) (XAU)",
+      "children": "Gold (troy ounce) (XAU)",
+      "id": "Gold (troy ounce) (XAU)"
+  },
+  {
+      "value": "XCD",
+      "label": "East Caribbean Dollar (XCD)",
+      "children": "East Caribbean Dollar (XCD)",
+      "id": "East Caribbean Dollar (XCD)"
+  },
+  {
+      "value": "XDR",
+      "label": "Special Drawing Rights (XDR)",
+      "children": "Special Drawing Rights (XDR)",
+      "id": "Special Drawing Rights (XDR)"
+  },
+  {
+      "value": "XOF",
+      "label": "CFA Franc BCEAO (XOF)",
+      "children": "CFA Franc BCEAO (XOF)",
+      "id": "CFA Franc BCEAO (XOF)"
+  },
+  {
+      "value": "XPF",
+      "label": "CFP Franc (XPF)",
+      "children": "CFP Franc (XPF)",
+      "id": "CFP Franc (XPF)"
+  },
+  {
+      "value": "YER",
+      "label": "Yemeni Rial (YER)",
+      "children": "Yemeni Rial (YER)",
+      "id": "Yemeni Rial (YER)"
+  },
+  {
+      "value": "ZAR",
+      "label": "South African Rand (ZAR)",
+      "children": "South African Rand (ZAR)",
+      "id": "South African Rand (ZAR)"
+  },
+  {
+      "value": "ZMK",
+      "label": "Zambian Kwacha (pre-2013) (ZMK)",
+      "children": "Zambian Kwacha (pre-2013) (ZMK)",
+      "id": "Zambian Kwacha (pre-2013) (ZMK)"
+  },
+  {
+      "value": "ZMW",
+      "label": "Zambian Kwacha (ZMW)",
+      "children": "Zambian Kwacha (ZMW)",
+      "id": "Zambian Kwacha (ZMW)"
+  },
+  {
+      "value": "ZWL",
+      "label": "Zimbabwean Dollar (ZWL)",
+      "children": "Zimbabwean Dollar (ZWL)",
+      "id": "Zimbabwean Dollar (ZWL)"
+  }
+]

--- a/src/Currency.test.tsx
+++ b/src/Currency.test.tsx
@@ -1,0 +1,72 @@
+import { describe, test, expect, beforeEach } from "vitest";
+import { cleanup, getAllByRole, getByText, render, screen } from "@testing-library/react";
+import Currency from "./Currency";
+import { useState } from "react";
+import userEvent from "@testing-library/user-event";
+import exchangeRateData from "./exchangeRateData";
+import '@testing-library/jest-dom/vitest';
+
+describe("<Currency />", () => {
+    const currencies = Object.keys(exchangeRateData.rates)
+    const user = userEvent.setup();
+    const TestComponent = ({ ...props }) => {
+        const [currency, setCurrency] = useState<string>("BRL");
+
+        return (
+            <Currency
+                currency={currency}
+                onCurrencyChange={(newValue) => {
+                    setCurrency(newValue);
+                }}
+                currencies={currencies}
+                {...props}
+            />
+        );
+    };
+
+    beforeEach(() => {
+        cleanup();
+        render(<TestComponent />);
+    });
+
+    test.only("dynamically renders currencies based on props", async () => {
+        cleanup();
+        render(<TestComponent currencies={["BRL", "MXN"]} />);
+
+        const currencyButton = screen.getByLabelText("Currency")
+        await user.click(currencyButton)
+        const popover = document.querySelector(".popover") as HTMLElement
+        const currencyOptions = getAllByRole(popover, 'option');
+        currencyOptions.forEach((option) => {
+            console.log(option.id)
+        })
+        expect(currencyOptions.length).toBe(2);
+    });
+
+    test("supports searching currency based on verbose name (i.e., Bitcoin) instead of ISO code (i.e., BTC)", async () => {
+        cleanup();
+        render(<TestComponent currencies={["BTC", "USD", "MXN"]} />);
+
+        const currencyButton = screen.getByLabelText("Currency")
+        await user.click(currencyButton)
+        await user.click(screen.getByPlaceholderText('Search for a currency...'))
+        await user.keyboard("bit")
+        expect(screen.getByText("Bitcoin", { exact: false })).toBeVisible();
+    });
+
+    test("doesn't \"unselect\" a currency when it's clicked once, then clicked again", async () => {
+        cleanup();
+        render(<TestComponent currencies={["BRL", "USD", "MXN"]} />);
+
+        const currencyButton = screen.getByLabelText("Currency")
+        await user.click(currencyButton)
+        const popover = document.querySelector(".popover") as HTMLElement
+        await user.click(getByText(popover, "BRL", { exact: false }))
+
+        expect(currencyButton.textContent).toBe("BRL");
+
+        await user.click(currencyButton)
+        await user.click(getByText(popover, "BRL", { exact: false }))
+        expect(currencyButton.textContent).toBe("BRL");
+    });
+})

--- a/src/Currency.test.tsx
+++ b/src/Currency.test.tsx
@@ -40,14 +40,16 @@ describe("<Currency />", () => {
         expect(currencyOptions.length).toBe(2);
     });
 
-    test("doesn't leave the popover in the DOM when it's not in use", () => {
+    test("doesn't leave the popover in the DOM when it's not in use", async () => {
         cleanup();
         render(<TestComponent currencies={["BRL", "MXN"]} />);
 
         const currencyButton = screen.getByLabelText("Currency")
-        waitFor(() => expect(document.querySelector(".popover")).toBeVisible());
-        user.click(currencyButton)
-        waitFor(() => expect(document.querySelector(".popover")).not.toBeInTheDocument());
+        expect(document.querySelector(".currency-popover")).not.toBeInTheDocument()
+        await user.click(currencyButton)
+        expect(document.querySelector(".currency-popover")).toBeVisible()
+        await user.click(currencyButton)
+        expect(document.querySelector(".currency-popover")).not.toBeInTheDocument()
     })
 
     test("supports searching currency based on verbose name (i.e., Bitcoin) instead of ISO code (i.e., BTC)", async () => {

--- a/src/Currency.test.tsx
+++ b/src/Currency.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from "vitest";
-import { cleanup, getAllByRole, getByText, render, screen } from "@testing-library/react";
+import { cleanup, getAllByRole, getByText, render, screen, waitFor } from "@testing-library/react";
 import Currency from "./Currency";
 import { useState } from "react";
 import userEvent from "@testing-library/user-event";
@@ -39,6 +39,16 @@ describe("<Currency />", () => {
         const currencyOptions = getAllByRole(popover, 'option');
         expect(currencyOptions.length).toBe(2);
     });
+
+    test("doesn't leave the popover in the DOM when it's not in use", () => {
+        cleanup();
+        render(<TestComponent currencies={["BRL", "MXN"]} />);
+
+        const currencyButton = screen.getByLabelText("Currency")
+        waitFor(() => expect(document.querySelector(".popover")).toBeVisible());
+        user.click(currencyButton)
+        waitFor(() => expect(document.querySelector(".popover")).not.toBeInTheDocument());
+    })
 
     test("supports searching currency based on verbose name (i.e., Bitcoin) instead of ISO code (i.e., BTC)", async () => {
         cleanup();

--- a/src/Currency.test.tsx
+++ b/src/Currency.test.tsx
@@ -29,7 +29,7 @@ describe("<Currency />", () => {
         render(<TestComponent />);
     });
 
-    test.only("dynamically renders currencies based on props", async () => {
+    test("dynamically renders currencies based on props", async () => {
         cleanup();
         render(<TestComponent currencies={["BRL", "MXN"]} />);
 

--- a/src/Currency.test.tsx
+++ b/src/Currency.test.tsx
@@ -37,9 +37,6 @@ describe("<Currency />", () => {
         await user.click(currencyButton)
         const popover = document.querySelector(".popover") as HTMLElement
         const currencyOptions = getAllByRole(popover, 'option');
-        currencyOptions.forEach((option) => {
-            console.log(option.id)
-        })
         expect(currencyOptions.length).toBe(2);
     });
 

--- a/src/Currency.test.tsx
+++ b/src/Currency.test.tsx
@@ -91,4 +91,20 @@ describe("<Currency />", () => {
         await user.click(getByText(popover, "BRL", { exact: false }))
         expect(currencyButton.textContent).toBe("BRL");
     });
+
+    test("shows a checkmark next to the selected currency", async () => {
+        cleanup();
+        render(<TestComponent currencies={["BRL", "USD", "MXN"]} />);
+
+        const currencyButton = screen.getByLabelText("Currency")
+        await user.click(currencyButton)
+        await user.click(screen.getByPlaceholderText('Search for a currency...'))
+        await user.keyboard("mxn{enter}")
+
+        expect(currencyButton.textContent).toBe("MXN");
+
+        await user.click(currencyButton)
+        expect(document.querySelector("#item-mxn")).toHaveAttribute("aria-selected", "true");
+        expect(document.querySelector("#item-mxn")).toHaveTextContent("✓");
+    });
 })

--- a/src/Currency.test.tsx
+++ b/src/Currency.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from "vitest";
-import { cleanup, getAllByRole, getByText, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, getAllByRole, getByText, render, screen } from "@testing-library/react";
 import Currency from "./Currency";
 import { useState } from "react";
 import userEvent from "@testing-library/user-event";
@@ -61,6 +61,19 @@ describe("<Currency />", () => {
         await user.click(screen.getByPlaceholderText('Search for a currency...'))
         await user.keyboard("bit")
         expect(screen.getByText("Bitcoin", { exact: false })).toBeVisible();
+    });
+
+    test("lets a user select a currency by focusing on the select and typing its code (no popover needed)", async () => {
+        cleanup();
+        render(<TestComponent currencies={["AED", "DJF", "USD"]} />);
+
+        const currencyButton = screen.getByLabelText("Currency")
+        await user.click(currencyButton)
+        expect(document.querySelector(".popover")).toBeVisible()
+        await user.click(currencyButton)
+        expect(document.querySelector(".popover")).not.toBeInTheDocument()
+        await user.keyboard("USD")
+        expect(currencyButton.textContent).toBe("USD");
     });
 
     test("doesn't \"unselect\" a currency when it's clicked once, then clicked again", async () => {

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -3,29 +3,39 @@ import { SelectRenderer } from "@ariakit/react-core/select/select-renderer";
 import kebabCase from "lodash-es/kebabCase.js";
 import { matchSorter } from "match-sorter";
 import { startTransition, useEffect, useState } from "react";
-import { symbols, } from "./exchangeRateData"
+import { symbols } from "./exchangeRateData";
 import "./Currency.css";
 
-function getItem({ code: currencyCode, name: currencyName }: { code: string, name: string }) {
+function getItem({
+    code: currencyCode,
+    displayName: currencyDisplayName,
+}: {
+    code: string;
+    displayName: string;
+}) {
     return {
         id: `item-${kebabCase(currencyCode)}`,
         value: currencyCode,
-        children: currencyName,
+        children: currencyDisplayName,
     };
 }
-
 
 export default function Currency({
     currency,
     onCurrencyChange,
-    currencies: currencyCodes
+    currencies: currencyCodes,
 }: {
-    currency: string,
-    onCurrencyChange: (newValue: string) => void,
-    currencies: string[]
+    currency: string;
+    onCurrencyChange: (newValue: string) => void;
+    currencies: string[];
 }) {
-
-    const currencies = currencyCodes.map((code) => ({ code, name: `${symbols[code as keyof typeof symbols]} (${code})` }))
+    const getCurrencies = () =>
+        currencyCodes.map((code) => ({
+            code,
+            name: symbols[code as keyof typeof symbols],
+            displayName: `${code}: ${symbols[code as keyof typeof symbols]}`,
+        }));
+    const [currencies] = useState(getCurrencies);
     const defaultItems = currencies.map(getItem);
 
     const [searchValue, setSearchValue] = useState("");
@@ -36,7 +46,7 @@ export default function Currency({
         resetValueOnHide: true,
         value: searchValue,
         setValue: setSearchValue,
-        placement: "bottom-end"
+        placement: "bottom-end",
     });
     const select = Ariakit.useSelectStore({
         combobox,
@@ -48,21 +58,23 @@ export default function Currency({
 
     useEffect(() => {
         startTransition(() => {
-            const items = matchSorter(currencies, searchValue, { keys: ["name"] });
+            const items = matchSorter(currencies, searchValue, { keys: ["displayName"] });
             setMatches(items.map(getItem));
         });
     }, [searchValue]);
 
     useEffect(() => {
-        onCurrencyChange(selectValue)
-    }, [onCurrencyChange, selectValue])
+        onCurrencyChange(selectValue);
+    }, [onCurrencyChange, selectValue]);
 
     return (
         <>
-            <Ariakit.Select store={select} className="currency-button button" aria-label="Currency">
-                <span className="select-value">
-                    {selectValue}
-                </span>
+            <Ariakit.Select
+                store={select}
+                className="currency-button button"
+                aria-label="Currency"
+            >
+                <span className="select-value">{selectValue}</span>
                 <Ariakit.SelectArrow />
             </Ariakit.Select>
             <Ariakit.SelectPopover
@@ -81,7 +93,6 @@ export default function Currency({
                 </div>
                 <Ariakit.ComboboxList store={combobox}>
                     <SelectRenderer store={select} items={matches} gap={8} overscan={1}>
-
                         {({ value, children, ...item }) => (
                             <Ariakit.ComboboxItem
                                 key={item.id}

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -9,18 +9,20 @@ import { startTransition, useEffect, useState } from "react";
 import { symbols, } from "./exchangeRateData"
 import "./Currency.css";
 
-const currencies = Object.keys(symbols)
+const currencyCodes = Object.keys(symbols)
+const currencyNames = Object.values(symbols)
 
-function getItem(currency: string) {
+function getItem(currencyCode: string) {
+    const currencyName = currencyNames[currencyCodes.indexOf(currencyCode)];
     return {
-        id: `item-${kebabCase(currency)}`,
-        value: currency,
-        label: `(${symbols[currency]}) (${currency})`,
-        children: currency,
+        id: `item-${kebabCase(currencyCode)}`,
+        value: currencyCode,
+        label: `${currencyName} (${currencyCode})`,
+        children: currencyCode,
     };
 }
 
-const defaultItems = currencies.map(getItem);
+const defaultItems = currencyCodes.map(getItem);
 
 export default function Currency() {
     const [searchValue, setSearchValue] = useState("");
@@ -43,7 +45,7 @@ export default function Currency() {
 
     useEffect(() => {
         startTransition(() => {
-            const items = matchSorter(currencies, searchValue);
+            const items = matchSorter(currencyCodes, searchValue);
             setMatches(items.map(getItem));
         });
     }, [searchValue]);
@@ -73,14 +75,14 @@ export default function Currency() {
                 <Ariakit.ComboboxList store={combobox}>
                     <SelectRenderer store={select} items={matches} gap={8} overscan={1}>
 
-                        {({ value, ...item }) => (
+                        {({ value, label, ...item }) => (
                             <Ariakit.ComboboxItem
                                 key={item.id}
                                 {...item}
                                 className="select-item"
                                 render={<Ariakit.SelectItem value={value} />}
                             >
-                                <span className="select-item-value">{value}</span>
+                                <span className="select-item-value">{value} {label}</span>
                             </Ariakit.ComboboxItem>
                         )}
                     </SelectRenderer>

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -19,7 +19,13 @@ function getItem({ code: currencyCode, name: currencyName }: { code: string, nam
 
 const defaultItems = currencies.map(getItem);
 
-export default function Currency() {
+export default function Currency({
+    currency,
+    onCurrencyChange,
+}: {
+    currency: string,
+    onCurrencyChange: (newValue: string) => void
+}) {
     const [searchValue, setSearchValue] = useState("");
     const [matches, setMatches] = useState(() => defaultItems);
 
@@ -33,7 +39,7 @@ export default function Currency() {
     const select = Ariakit.useSelectStore({
         combobox,
         defaultItems,
-        defaultValue: "",
+        defaultValue: currency,
     });
 
     const selectValue = Ariakit.useStoreState(select, "value");
@@ -45,9 +51,13 @@ export default function Currency() {
         });
     }, [searchValue]);
 
+    useEffect(() => {
+        onCurrencyChange(selectValue)
+    }, [onCurrencyChange, selectValue])
+
     return (
         <>
-            <Ariakit.Select store={select} className="currency-button button">
+            <Ariakit.Select store={select} className="currency-button button" aria-label="Currency">
                 <span className="select-value">
                     {selectValue}
                 </span>

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -68,8 +68,8 @@ export default function Currency({
             <Ariakit.SelectPopover
                 store={select}
                 gutter={4}
-                className="popover"
-
+                className="currency-popover popover"
+                unmountOnHide={true}
             >
                 <div className="combobox-wrapper">
                     <Ariakit.Combobox

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -16,10 +16,13 @@ const Currency = ({
     handleCurrencyChange: (newValue: string) => void,
     currencies: string[]
 }) => {
-    const verboseCurrencies = countries.map(code => {
+    const getMassiveCurrencyList = () => countries.map(code => {
         const verboseString = `${symbols[code as keyof typeof symbols]} (${code})`
         return { value: code, label: verboseString, children: verboseString, id: verboseString }
     })
+
+    const [verboseCurrencies] = useState(getMassiveCurrencyList)
+
     const defaultItems = verboseCurrencies;
     const [searchValue, setSearchValue] = useState("");
     const [matches, setMatches] = useState(() => defaultItems);
@@ -44,7 +47,7 @@ const Currency = ({
             const items = matchSorter(verboseCurrencies, searchValue, { keys: ['label'] });
             setMatches(items);
         });
-    }, [searchValue]);
+    }, [verboseCurrencies, searchValue]);
 
     useEffect(() => {
         handleCurrencyChange(selectValue)

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -100,7 +100,7 @@ export default function Currency({
                                 className="select-item"
                                 render={<Ariakit.SelectItem value={value} />}
                             >
-                                <span className="select-item-value">{children}</span>
+                                <span className="select-item-value">{(selectValue === value ? "✓" : "")} {children}</span>
                             </Ariakit.ComboboxItem>
                         )}
                     </SelectRenderer>

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -6,9 +6,6 @@ import { startTransition, useEffect, useState } from "react";
 import { symbols, } from "./exchangeRateData"
 import "./Currency.css";
 
-const currencyCodes = Object.keys(symbols)
-const currencies = currencyCodes.map((code) => ({ code, name: `${symbols[code]} (${code})` }))
-
 function getItem({ code: currencyCode, name: currencyName }: { code: string, name: string }) {
     return {
         id: `item-${kebabCase(currencyCode)}`,
@@ -17,15 +14,20 @@ function getItem({ code: currencyCode, name: currencyName }: { code: string, nam
     };
 }
 
-const defaultItems = currencies.map(getItem);
 
 export default function Currency({
     currency,
     onCurrencyChange,
+    currencies: currencyCodes
 }: {
     currency: string,
-    onCurrencyChange: (newValue: string) => void
+    onCurrencyChange: (newValue: string) => void,
+    currencies: string[]
 }) {
+
+    const currencies = currencyCodes.map((code) => ({ code, name: `${symbols[code]} (${code})` }))
+    const defaultItems = currencies.map(getItem);
+
     const [searchValue, setSearchValue] = useState("");
     const [matches, setMatches] = useState(() => defaultItems);
 

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -7,19 +7,17 @@ import { symbols, } from "./exchangeRateData"
 import "./Currency.css";
 
 const currencyCodes = Object.keys(symbols)
-const currencyNames = Object.values(symbols)
+const currencies = currencyCodes.map((code) => ({ code, name: `${symbols[code]} (${code})` }))
 
-function getItem(currencyCode: string) {
-    const currencyName = currencyNames[currencyCodes.indexOf(currencyCode)];
+function getItem({ code: currencyCode, name: currencyName }: { code: string, name: string }) {
     return {
         id: `item-${kebabCase(currencyCode)}`,
         value: currencyCode,
-        label: `${currencyName} (${currencyCode})`,
-        children: currencyCode,
+        children: currencyName,
     };
 }
 
-const defaultItems = currencyCodes.map(getItem);
+const defaultItems = currencies.map(getItem);
 
 export default function Currency() {
     const [searchValue, setSearchValue] = useState("");
@@ -42,7 +40,7 @@ export default function Currency() {
 
     useEffect(() => {
         startTransition(() => {
-            const items = matchSorter(currencyCodes, searchValue);
+            const items = matchSorter(currencies, searchValue, { keys: ["name"] });
             setMatches(items.map(getItem));
         });
     }, [searchValue]);
@@ -72,14 +70,14 @@ export default function Currency() {
                 <Ariakit.ComboboxList store={combobox}>
                     <SelectRenderer store={select} items={matches} gap={8} overscan={1}>
 
-                        {({ value, label, ...item }) => (
+                        {({ value, children, ...item }) => (
                             <Ariakit.ComboboxItem
                                 key={item.id}
                                 {...item}
                                 className="select-item"
                                 render={<Ariakit.SelectItem value={value} />}
                             >
-                                <span className="select-item-value">{value} {label}</span>
+                                <span className="select-item-value">{children}</span>
                             </Ariakit.ComboboxItem>
                         )}
                     </SelectRenderer>

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -36,7 +36,7 @@ const defaultItems = currencies.map(getItem);
 
 export default function Currency() {
     const [searchValue, setSearchValue] = useState("");
-    const [matches, setMatches] = useState(() => groupItems(defaultItems));
+    const [matches, setMatches] = useState(() => defaultItems);
 
     const combobox = Ariakit.useComboboxStore({
         defaultItems,
@@ -56,7 +56,7 @@ export default function Currency() {
     useEffect(() => {
         startTransition(() => {
             const items = matchSorter(currencies, searchValue);
-            setMatches(groupItems(items.map(getItem)));
+            setMatches(items.map(getItem));
         });
     }, [searchValue]);
 
@@ -85,32 +85,16 @@ export default function Currency() {
                 </div>
                 <Ariakit.ComboboxList store={combobox}>
                     <SelectRenderer store={select} items={matches} gap={8} overscan={1}>
-                        {({ label, ...item }) => (
-                            <SelectRenderer
+
+                        {({ value, ...item }) => (
+                            <Ariakit.ComboboxItem
                                 key={item.id}
-                                className="group"
-                                overscan={1}
                                 {...item}
-                                render={(props) => (
-                                    <Ariakit.SelectGroup {...props}>
-                                        <Ariakit.SelectGroupLabel className="group-label">
-                                            {label}
-                                        </Ariakit.SelectGroupLabel>
-                                        {props.children}
-                                    </Ariakit.SelectGroup>
-                                )}
+                                className="select-item"
+                                render={<Ariakit.SelectItem value={value} />}
                             >
-                                {({ value, ...item }) => (
-                                    <Ariakit.ComboboxItem
-                                        key={item.id}
-                                        {...item}
-                                        className="select-item"
-                                        render={<Ariakit.SelectItem value={value} />}
-                                    >
-                                        <span className="select-item-value">{value}</span>
-                                    </Ariakit.ComboboxItem>
-                                )}
-                            </SelectRenderer>
+                                <span className="select-item-value">{value}</span>
+                            </Ariakit.ComboboxItem>
                         )}
                     </SelectRenderer>
                 </Ariakit.ComboboxList>

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -1,8 +1,5 @@
 import * as Ariakit from "@ariakit/react";
 import { SelectRenderer } from "@ariakit/react-core/select/select-renderer";
-import type { SelectRendererItem } from "@ariakit/react-core/select/select-renderer";
-import deburr from "lodash-es/deburr.js";
-import groupBy from "lodash-es/groupBy.js";
 import kebabCase from "lodash-es/kebabCase.js";
 import { matchSorter } from "match-sorter";
 import { startTransition, useEffect, useState } from "react";

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -11,25 +11,13 @@ import "./Currency.css";
 
 const currencies = Object.keys(symbols)
 
-function getItem(country: string) {
+function getItem(currency: string) {
     return {
-        id: `item-${kebabCase(country)}`,
-        value: country,
-        children: country,
+        id: `item-${kebabCase(currency)}`,
+        value: currency,
+        label: `(${symbols[currency]}) (${currency})`,
+        children: currency,
     };
-}
-
-function groupItems(items: ReturnType<typeof getItem>[]) {
-    const groups = groupBy(items, (item) => deburr(item.value?.at(0)));
-    return Object.entries(groups).map(([label, items]) => {
-        return {
-            id: `group-${label.toLowerCase()}`,
-            label,
-            itemSize: 40,
-            paddingStart: 44,
-            items,
-        } satisfies SelectRendererItem;
-    });
 }
 
 const defaultItems = currencies.map(getItem);
@@ -62,10 +50,9 @@ export default function Currency() {
 
     return (
         <>
-            <Ariakit.SelectLabel store={select}>Country</Ariakit.SelectLabel>
-            <Ariakit.Select store={select} className="button">
+            <Ariakit.Select store={select} className="currency-button button">
                 <span className="select-value">
-                    {selectValue || "Select a country"}
+                    {selectValue}
                 </span>
                 <Ariakit.SelectArrow />
             </Ariakit.Select>
@@ -79,7 +66,7 @@ export default function Currency() {
                     <Ariakit.Combobox
                         store={combobox}
                         autoSelect
-                        placeholder="Search..."
+                        placeholder="Search for a currency..."
                         className="combobox"
                     />
                 </div>

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -1,31 +1,42 @@
-"use client"
-
 import * as Ariakit from "@ariakit/react";
 import { SelectRenderer } from "@ariakit/react-core/select/select-renderer";
+import type { SelectRendererItem } from "@ariakit/react-core/select/select-renderer";
+import deburr from "lodash-es/deburr.js";
+import groupBy from "lodash-es/groupBy.js";
+import kebabCase from "lodash-es/kebabCase.js";
 import { matchSorter } from "match-sorter";
 import { startTransition, useEffect, useState } from "react";
-import "./Currency.css"
-import { symbols } from "./exchangeRateData";
+import { symbols, } from "./exchangeRateData"
+import "./Currency.css";
 
-const Currency = ({
-    currency,
-    handleCurrencyChange,
-    currencies: countries
-}: {
-    currency: string,
-    handleCurrencyChange: (newValue: string) => void,
-    currencies: string[]
-}) => {
-    const getMassiveCurrencyList = () => countries.map(code => {
-        const verboseString = `${symbols[code as keyof typeof symbols]} (${code})`
-        return { value: code, label: verboseString, children: verboseString, id: verboseString }
-    })
+const currencies = Object.keys(symbols)
 
-    const [verboseCurrencies] = useState(getMassiveCurrencyList)
+function getItem(country: string) {
+    return {
+        id: `item-${kebabCase(country)}`,
+        value: country,
+        children: country,
+    };
+}
 
-    const defaultItems = verboseCurrencies;
+function groupItems(items: ReturnType<typeof getItem>[]) {
+    const groups = groupBy(items, (item) => deburr(item.value?.at(0)));
+    return Object.entries(groups).map(([label, items]) => {
+        return {
+            id: `group-${label.toLowerCase()}`,
+            label,
+            itemSize: 40,
+            paddingStart: 44,
+            items,
+        } satisfies SelectRendererItem;
+    });
+}
+
+const defaultItems = currencies.map(getItem);
+
+export default function Currency() {
     const [searchValue, setSearchValue] = useState("");
-    const [matches, setMatches] = useState(() => defaultItems);
+    const [matches, setMatches] = useState(() => groupItems(defaultItems));
 
     const combobox = Ariakit.useComboboxStore({
         defaultItems,
@@ -37,27 +48,24 @@ const Currency = ({
     const select = Ariakit.useSelectStore({
         combobox,
         defaultItems,
-        defaultValue: currency,
+        defaultValue: "",
     });
 
     const selectValue = Ariakit.useStoreState(select, "value");
 
     useEffect(() => {
         startTransition(() => {
-            const items = matchSorter(verboseCurrencies, searchValue, { keys: ['label'] });
-            setMatches(items);
+            const items = matchSorter(currencies, searchValue);
+            setMatches(groupItems(items.map(getItem)));
         });
-    }, [verboseCurrencies, searchValue]);
-
-    useEffect(() => {
-        handleCurrencyChange(selectValue)
-    }, [handleCurrencyChange, selectValue])
+    }, [searchValue]);
 
     return (
         <>
-            <Ariakit.Select store={select} className="currency-button button" aria-label="Currency">
+            <Ariakit.SelectLabel store={select}>Country</Ariakit.SelectLabel>
+            <Ariakit.Select store={select} className="button">
                 <span className="select-value">
-                    {selectValue || currency}
+                    {selectValue || "Select a country"}
                 </span>
                 <Ariakit.SelectArrow />
             </Ariakit.Select>
@@ -65,33 +73,48 @@ const Currency = ({
                 store={select}
                 gutter={4}
                 className="popover"
-                unmountOnHide={true}
+
             >
                 <div className="combobox-wrapper">
                     <Ariakit.Combobox
                         store={combobox}
                         autoSelect
-                        placeholder="Search for a currency..."
+                        placeholder="Search..."
                         className="combobox"
                     />
                 </div>
                 <Ariakit.ComboboxList store={combobox}>
                     <SelectRenderer store={select} items={matches} gap={8} overscan={1}>
-                        {({ value, ...item }) => (
-                            <Ariakit.ComboboxItem
+                        {({ label, ...item }) => (
+                            <SelectRenderer
                                 key={item.id}
+                                className="group"
+                                overscan={1}
                                 {...item}
-                                className="select-item"
-                                render={<Ariakit.SelectItem value={value}>{selectValue === value ? "✓" : ""} {item.label}</Ariakit.SelectItem>}
+                                render={(props) => (
+                                    <Ariakit.SelectGroup {...props}>
+                                        <Ariakit.SelectGroupLabel className="group-label">
+                                            {label}
+                                        </Ariakit.SelectGroupLabel>
+                                        {props.children}
+                                    </Ariakit.SelectGroup>
+                                )}
                             >
-                                <span className="select-item-value">{value}</span>
-                            </Ariakit.ComboboxItem>
+                                {({ value, ...item }) => (
+                                    <Ariakit.ComboboxItem
+                                        key={item.id}
+                                        {...item}
+                                        className="select-item"
+                                        render={<Ariakit.SelectItem value={value} />}
+                                    >
+                                        <span className="select-item-value">{value}</span>
+                                    </Ariakit.ComboboxItem>
+                                )}
+                            </SelectRenderer>
                         )}
                     </SelectRenderer>
                 </Ariakit.ComboboxList>
             </Ariakit.SelectPopover>
         </>
-    )
+    );
 }
-
-export default Currency;

--- a/src/Currency.tsx
+++ b/src/Currency.tsx
@@ -25,7 +25,7 @@ export default function Currency({
     currencies: string[]
 }) {
 
-    const currencies = currencyCodes.map((code) => ({ code, name: `${symbols[code]} (${code})` }))
+    const currencies = currencyCodes.map((code) => ({ code, name: `${symbols[code as keyof typeof symbols]} (${code})` }))
     const defaultItems = currencies.map(getItem);
 
     const [searchValue, setSearchValue] = useState("");

--- a/src/GasPrice.test.tsx
+++ b/src/GasPrice.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from "vitest";
-import { cleanup, getAllByRole, getByText, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import GasPrice from "./GasPrice";
 import { useState } from "react";
 import userEvent from "@testing-library/user-event";
@@ -174,44 +174,6 @@ describe("<GasPrice />", () => {
     await user.keyboard(",");
 
     expect(input.value).toBe("1.00");
-  });
-
-  test("dynamically renders currencies based on props", async () => {
-    cleanup();
-    render(<TestComponent currencies={["BRL", "MXN"]} />);
-
-    const currencyButton = screen.getByLabelText("Currency")
-    await user.click(currencyButton)
-    const popover = document.querySelector(".popover") as HTMLElement
-    const currencyOptions = getAllByRole(popover, 'option');
-    expect(currencyOptions.length).toBe(2);
-  });
-
-  test("supports searching currency based on verbose name (i.e., Bitcoin) instead of ISO code (i.e., BTC)", async () => {
-    cleanup();
-    render(<TestComponent currencies={["BTC", "USD", "MXN"]} />);
-
-    const currencyButton = screen.getByLabelText("Currency")
-    await user.click(currencyButton)
-    await user.click(screen.getByPlaceholderText('Search for a currency...'))
-    await user.keyboard("bit")
-    expect(screen.getByText("Bitcoin", { exact: false })).toBeVisible();
-  });
-
-  test("doesn't \"unselect\" a currency when it's clicked once, then clicked again", async () => {
-    cleanup();
-    render(<TestComponent currencies={["BRL", "USD", "MXN"]} />);
-
-    const currencyButton = screen.getByLabelText("Currency")
-    await user.click(currencyButton)
-    const popover = document.querySelector(".popover") as HTMLElement
-    await user.click(getByText(popover, "BRL", { exact: false }))
-
-    expect(currencyButton.textContent).toBe("BRL");
-
-    await user.click(currencyButton)
-    await user.click(getByText(popover, "BRL", { exact: false }))
-    expect(currencyButton.textContent).toBe("BRL");
   });
 
   test("warns when a display value is 0 but the actual value is not", async () => {

--- a/src/GasPrice.tsx
+++ b/src/GasPrice.tsx
@@ -83,7 +83,7 @@ function GasPrice({
         />
         <Currency
           currency={currency}
-          handleCurrencyChange={handleCurrencyChange}
+          onCurrencyChange={handleCurrencyChange}
           currencies={currencies}
         ></Currency>
         <Unit


### PR DESCRIPTION
I also added some usability stuff here:
* Checkmark for selected option
* Change currency/name order to support typeahead (type in select without opening popover)
* Unmount popover when not in use