### PR TITLE
💱 feat: Support currencies with various decimal places

### DIFF
--- a/src/GasPrice.test.tsx
+++ b/src/GasPrice.test.tsx
@@ -4,6 +4,7 @@ import GasPrice from "./GasPrice";
 import { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
+import { selectItemFromFancySelect } from "./utils/testUtils";
 
 describe("<GasPrice />", () => {
   const user = userEvent.setup();
@@ -55,7 +56,24 @@ describe("<GasPrice />", () => {
       exact: false,
     }) as HTMLInputElement;
 
+    const currencyDropdown = screen.getByRole("combobox", {
+      name: "Currency",
+    }) as HTMLSelectElement;
+
+    // Supports 2 decimal places
     expect(input.value).toBe("0.00");
+    await user.click(input);
+    expect(input.value).toBe("");
+
+    // Supports 3 decimal places
+    await selectItemFromFancySelect(currencyDropdown, "TND");
+    expect(input.value).toBe("0.000");
+    await user.click(input);
+    expect(input.value).toBe("");
+
+    // Supports 0 decimal places
+    await selectItemFromFancySelect(currencyDropdown, "JPY");
+    expect(input.value).toBe("0");
     await user.click(input);
     expect(input.value).toBe("");
   });

--- a/src/GasPrice.tsx
+++ b/src/GasPrice.tsx
@@ -35,20 +35,14 @@ function GasPrice({
   disabled?: boolean;
 }) {
   const [displayNumber, setDisplayNumber] = useState(
-    getFormattedPrice(number >= 0.01 ? number : 0.01, "en-US", currency),
+    getFormattedPrice(number, "en-US", currency),
   );
   const [isNumberFocused, setIsNumberFocused] = useState(false);
 
   useEffect(() => {
     if (isNumberFocused) return;
 
-    setDisplayNumber(
-      getFormattedPrice(
-        number > 0.01 || number === 0 ? number : 0.01,
-        "en-US",
-        currency,
-      ),
-    );
+    setDisplayNumber(getFormattedPrice(number, "en-US", currency));
   }, [number, currency, isNumberFocused]);
 
   const handleDisplayNumberChange = (
@@ -106,11 +100,11 @@ function GasPrice({
           onUnitChange={handleUnitChange}
         />
       </fieldset>
-      {displayNumber === "0.01" && number < 0.01 ? (
+      {Number(displayNumber) > number ? (
         <p className="mt-4">
           <em>
-            This amount is displayed as 0.01 {currency}, but the actual amount
-            is less ({number} {currency})
+            This amount is displayed as {displayNumber} {currency}, but the
+            actual amount is less ({number} {currency})
           </em>
         </p>
       ) : (

--- a/src/utils/getGasPrice.test.ts
+++ b/src/utils/getGasPrice.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import getGasPrice from "./utils/getGasPrice";
+import getGasPrice from "./getGasPrice";
 
 describe("getGasPrice method", () => {
   const fakeExchangeRates = {

--- a/src/utils/numberFormat.test.ts
+++ b/src/utils/numberFormat.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "vitest";
+import { describe, test, expect } from "vitest";
 import { getFormattedPrice, isTinyNumber } from "./numberFormat";
 
 describe("getFormattedPrice method", () => {
@@ -36,7 +36,7 @@ describe("getFormattedPrice method", () => {
 
 describe("isTinyNumber method", () => {
     let tinyValue = 0.00001
-    let userLocale = "en-US"
+    const userLocale = "en-US"
     let userCurrency = "USD"
 
   test("returns true for 0.00001 USD in en-US", () => {

--- a/src/utils/numberFormat.test.ts
+++ b/src/utils/numberFormat.test.ts
@@ -1,5 +1,5 @@
-import { describe, test, expect } from "vitest";
-import { getFormattedPrice } from "./numberFormat";
+import { describe, test, expect, beforeEach } from "vitest";
+import { getFormattedPrice, isTinyNumber } from "./numberFormat";
 
 describe("getFormattedPrice method", () => {
   test("formats tiny non-0 prices as the smallest practical value possible for the currency", () => {
@@ -33,3 +33,24 @@ describe("getFormattedPrice method", () => {
       expect(result).toBe("0.001");
   });
 });
+
+describe("isTinyNumber method", () => {
+    let tinyValue = 0.00001
+    let userLocale = "en-US"
+    let userCurrency = "USD"
+
+  test("returns true for 0.00001 USD in en-US", () => {
+    expect(isTinyNumber(tinyValue, userLocale, userCurrency)).toBe(true)
+  })
+
+  test("returns false for 0", () => {
+    tinyValue = 0
+    expect(isTinyNumber(tinyValue, userLocale, userCurrency)).toBe(false)
+  })
+
+  test("returns false for numbers that can be expressed with the currency's decimal places", () => {
+    tinyValue = 0.001
+    userCurrency = "TND"
+    expect(isTinyNumber(tinyValue, userLocale, userCurrency)).toBe(false)
+})
+})

--- a/src/utils/numberFormat.test.ts
+++ b/src/utils/numberFormat.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "vitest";
+import { getFormattedPrice } from "./numberFormat";
+
+describe("getFormattedPrice method", () => {
+  test("formats tiny non-0 prices as the smallest practical value possible for the currency", () => {
+    const tinyValue = 0.00001
+    let result = ""
+    
+    // JPY just uses integers
+    result = getFormattedPrice(
+      tinyValue,
+      "en-US",
+      "JPY",
+    );
+    expect(result).toBe("1");
+
+    // USD uses 2 decimal places
+    result = getFormattedPrice(
+        tinyValue,
+        "en-US",
+        "USD",
+      );
+  
+      expect(result).toBe("0.01");
+
+    // TND uses 3 decimal places
+    result = getFormattedPrice(
+        tinyValue,
+        "en-US",
+        "TND",
+      );
+  
+      expect(result).toBe("0.001");
+  });
+});

--- a/src/utils/numberFormat.ts
+++ b/src/utils/numberFormat.ts
@@ -53,7 +53,7 @@ const getFormattedPrice = (
 
   // If we're formatting the number to look like 0 but the value isn't 0,
   //  replace the last 0 with a 1
-  if (Number(formattedNumber) === 0 && price !== 0) {
+  if (isTinyNumber(price, userLocale, currency)) {
     formattedNumber = formattedNumber.replace(/0$/, "1");
   }
 

--- a/src/utils/numberFormat.ts
+++ b/src/utils/numberFormat.ts
@@ -13,6 +13,28 @@ const getNumberFormatChar = (
   return chars[char];
 };
 
+const isTinyNumber = (number: number, userLocale = "en-US", currency = "USD") => {
+  if (number === 0 || number >= 1) {
+    return false
+  }
+
+  const formattedNumber = 
+  Intl.NumberFormat(userLocale, {
+    style: "currency",
+    currency: currency,
+    currencyDisplay: "code",
+  })
+  .format(number)
+  .replace(currency, "")
+  .trim()
+
+  if (Number(formattedNumber) === 0) {
+    return true
+  }
+
+  return false
+}
+
 const getFormattedPrice = (
   price: number,
   userLocale = "en-US",
@@ -80,4 +102,4 @@ const getUnits = (
   return price;
 };
 
-export { getUnits, getNumberFormatChar, getFormattedPrice, isLegalPriceValue };
+export { getUnits, getNumberFormatChar, getFormattedPrice, isLegalPriceValue, isTinyNumber };

--- a/src/utils/numberFormat.ts
+++ b/src/utils/numberFormat.ts
@@ -18,14 +18,24 @@ const getFormattedPrice = (
   userLocale = "en-US",
   currency = "USD",
 ) => {
-  return Intl.NumberFormat(userLocale, {
+  let formattedNumber = String(price);
+  
+  formattedNumber = Intl.NumberFormat(userLocale, {
     style: "currency",
     currency: currency,
     currencyDisplay: "code",
   })
-    .format(price)
-    .replace(currency, "")
-    .trim();
+  .format(price)
+  .replace(currency, "")
+  .trim();
+
+  // If we're formatting the number to look like 0 but the value isn't 0,
+  //  replace the last 0 with a 1
+  if (Number(formattedNumber) === 0 && price !== 0) {
+    formattedNumber = formattedNumber.replace(/0$/, "1");
+  }
+
+  return formattedNumber
 };
 
 const isLegalPriceValue = (price: string) => {


### PR DESCRIPTION
This change improves handling for edge cases with tiny amounts of currency:
- Show a warning when the actual value is less than the display value
- Show currency values that get rounded to 0 as the smallest non-0 value they support

Close #94