### PR TITLE
🐛 fix: Stop showing tiny value warning for non-tiny values

### DIFF
--- a/src/GasPrice.test.tsx
+++ b/src/GasPrice.test.tsx
@@ -203,9 +203,28 @@ describe("<GasPrice />", () => {
     await user.tab();
     expect(input.value).toBe("0.01");
 
-    const warning = screen.getByText("This amount is displayed as 0.01", {
+    const warning = screen.queryByText("This amount is displayed as", {
       exact: false,
     });
     expect(warning).toBeVisible();
+  });
+
+  test("doesn't warn just because the number is less than the display number", async () => {
+    cleanup();
+    render(<TestComponent />);
+
+    const input = screen.getByLabelText("Amount", {
+      exact: false,
+    }) as HTMLInputElement;
+
+    await user.click(input);
+    await user.keyboard("69.13733353240167");
+    await user.tab();
+    expect(input.value).toBe("69.14");
+
+    const warning = screen.queryByText("This amount is displayed as", {
+      exact: false,
+    });
+    expect(warning).not.toBeInTheDocument();
   });
 });

--- a/src/GasPrice.tsx
+++ b/src/GasPrice.tsx
@@ -4,6 +4,7 @@ import {
   getFormattedPrice,
   getParsedNumber,
   isLegalPriceValue,
+  isTinyNumber,
 } from "./utils/numberFormat";
 import Currency from "./Currency";
 import Unit from "./Unit";
@@ -95,9 +96,9 @@ function GasPrice({
           onUnitChange={handleUnitChange}
         />
       </fieldset>
-      {Number(displayNumber) > number ? (
+      {isTinyNumber(number, userLocale, currency) ? (
         <p className="mt-4">
-          <em>
+          <em role="status">
             This amount is displayed as {displayNumber} {currency}, but the
             actual amount is less ({number} {currency})
           </em>


### PR DESCRIPTION
<img width="426" alt="Screenshot 2024-12-25 at 9 56 56 PM" src="https://github.com/user-attachments/assets/438cdfe8-13e9-461c-987c-1ee6b6482db8" />
