### PR TITLE
📡 feat: Add user analytics

### DIFF
--- a/src/entry.client.tsx
+++ b/src/entry.client.tsx
@@ -3,21 +3,6 @@ import ReactDOM from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 import "./index.css";
 
-{
-  /* <StrictMode>
-<BrowserRouter>
-  <Routes>
-    <Route index element={<I18nWrapper language="en" />}></Route>
-    <Route path="en" element={<Navigate to="/" />}></Route>
-    <Route path="de" element={<I18nWrapper language="de" />}></Route>
-    <Route path="es" element={<I18nWrapper language="es" />}></Route>
-    <Route path="hi" element={<I18nWrapper language="hi" />}></Route>
-    <Route path="pt" element={<I18nWrapper language="pt" />}></Route>
-  </Routes>
-</BrowserRouter>
-</StrictMode>, */
-}
-
 ReactDOM.hydrateRoot(
   document,
   <React.StrictMode>

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -16,6 +16,12 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <div id="root">{children}</div>
         <ScrollRestoration />
         <Scripts />
+        {/* <!-- 100% privacy-first analytics --> */}
+        <script
+          data-collect-dnt="true"
+          async
+          src="https://scripts.simpleanalyticscdn.com/latest.js"
+        ></script>
       </body>
     </html>
   );


### PR DESCRIPTION
This change adds Simple Analytics, which should let me see some basic info about how my site is used and won't require me to implement a cookie consent banner. Since a big part of my intended audience is from countries with laws about data collection, Simple Analytics makes sense for me now.

I don't want to burden users with a consent banner or break the law.