### PR TITLE
🔍 feat: Make foreign language pages easier to find

### DIFF
--- a/src/languages/pt.ts
+++ b/src/languages/pt.ts
@@ -1,8 +1,8 @@
 export default {
   // Meta Data
-  meta_title: "Conversor de preço de gás",
+  meta_title: "Conversor de preço de combustível",
   meta_description:
-    "Converta instantaneamente os preços da gasolina listados em unidades e moedas estrangeiras",
+    "Converta preços de combustível listados em litros ou galões, vendidos em dólares, euros, e outras moedas estrangeiras",
 
   // App.tsx
   gasCost: "Preço da Gasolina",

--- a/src/pages/home-de.tsx
+++ b/src/pages/home-de.tsx
@@ -1,6 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
-export { links } from "./home-defaults.ts";
+import { links as defaultLinks } from "./home-defaults.ts";
 import de from "../languages/de.ts";
 
 const language = "de";
@@ -9,6 +9,10 @@ const intl = createIntl({
   locale: language,
   messages: de,
 });
+
+export const links = () => {
+  return [...defaultLinks(), { rel: "canonical", href: "https://gasco.st/de" }];
+};
 
 export function meta() {
   return [

--- a/src/pages/home-de.tsx
+++ b/src/pages/home-de.tsx
@@ -1,5 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
+export { links } from "./home-defaults.ts";
 import de from "../languages/de.ts";
 
 const language = "de";

--- a/src/pages/home-de.tsx
+++ b/src/pages/home-de.tsx
@@ -1,6 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
-import { links as defaultLinks } from "./home-defaults.ts";
+import { defaultLinks } from "./home-defaults.ts";
 import de from "../languages/de.ts";
 
 const language = "de";

--- a/src/pages/home-defaults.ts
+++ b/src/pages/home-defaults.ts
@@ -1,7 +1,12 @@
 // React Router uses various objects (meta, links, scripts, etc.) to build pages
-// This file defines the defaults for those objects
+// This file defines the defaults for those objects, which are used in `home-*.tsx`
 
-export const links = () => {
+export const defaultLinks = () => {
+  // This implements the advice of:
+  // * Each page lists every alternate language version of the page
+  // * Each page is self-canonicalized
+  // * Each page uses absolute URLs
+  // (Source: [Portent blog](https://portent.com/blog/seo/implement-hreflang-canonical-tags-correctly.htm))
   return [
     { rel: "alternate", hrefLang: "en", href: "https://gasco.st/" },
     { rel: "alternate", hrefLang: "de", href: "https://gasco.st/de" },

--- a/src/pages/home-defaults.ts
+++ b/src/pages/home-defaults.ts
@@ -3,11 +3,11 @@
 
 export const links = () => {
   return [
-    { rel: "alternate", hrefLang: "en", href: "/" },
-    { rel: "alternate", hrefLang: "de", href: "/de" },
-    { rel: "alternate", hrefLang: "pt", href: "/pt" },
-    { rel: "alternate", hrefLang: "es", href: "/es" },
-    { rel: "alternate", hrefLang: "hi", href: "/hi" },
-    { rel: "alternate", hrefLang: "x-default", href: "/" },
+    { rel: "alternate", hrefLang: "en", href: "https://gasco.st/" },
+    { rel: "alternate", hrefLang: "de", href: "https://gasco.st/de" },
+    { rel: "alternate", hrefLang: "pt", href: "https://gasco.st/pt" },
+    { rel: "alternate", hrefLang: "es", href: "https://gasco.st/es" },
+    { rel: "alternate", hrefLang: "hi", href: "https://gasco.st/hi" },
+    { rel: "alternate", hrefLang: "x-default", href: "https://gasco.st/" },
   ];
 };

--- a/src/pages/home-defaults.ts
+++ b/src/pages/home-defaults.ts
@@ -1,0 +1,13 @@
+// React Router uses various objects (meta, links, scripts, etc.) to build pages
+// This file defines the defaults for those objects
+
+export const links = () => {
+  return [
+    { rel: "alternate", hrefLang: "en", href: "/" },
+    { rel: "alternate", hrefLang: "de", href: "/de" },
+    { rel: "alternate", hrefLang: "pt", href: "/pt" },
+    { rel: "alternate", hrefLang: "es", href: "/es" },
+    { rel: "alternate", hrefLang: "hi", href: "/hi" },
+    { rel: "alternate", hrefLang: "x-default", href: "/" },
+  ];
+};

--- a/src/pages/home-en.tsx
+++ b/src/pages/home-en.tsx
@@ -1,6 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
-export { links } from "./home-defaults.ts";
+import { links as defaultLinks } from "./home-defaults.ts";
 import en from "../languages/en.ts";
 
 const language = "en";
@@ -9,6 +9,10 @@ const intl = createIntl({
   locale: language,
   messages: en,
 });
+
+export const links = () => {
+  return [...defaultLinks(), { rel: "canonical", href: "https://gasco.st/" }];
+};
 
 export function meta() {
   return [

--- a/src/pages/home-en.tsx
+++ b/src/pages/home-en.tsx
@@ -1,5 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
+export { links } from "./home-defaults.ts";
 import en from "../languages/en.ts";
 
 const language = "en";

--- a/src/pages/home-en.tsx
+++ b/src/pages/home-en.tsx
@@ -1,6 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
-import { links as defaultLinks } from "./home-defaults.ts";
+import { defaultLinks } from "./home-defaults.ts";
 import en from "../languages/en.ts";
 
 const language = "en";

--- a/src/pages/home-es.tsx
+++ b/src/pages/home-es.tsx
@@ -1,6 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
-import { links as defaultLinks } from "./home-defaults.ts";
+import { defaultLinks } from "./home-defaults.ts";
 import es from "../languages/es.ts";
 
 const language = "es";

--- a/src/pages/home-es.tsx
+++ b/src/pages/home-es.tsx
@@ -1,5 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
+export { links } from "./home-defaults.ts";
 import es from "../languages/es.ts";
 
 const language = "es";

--- a/src/pages/home-es.tsx
+++ b/src/pages/home-es.tsx
@@ -1,6 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
-export { links } from "./home-defaults.ts";
+import { links as defaultLinks } from "./home-defaults.ts";
 import es from "../languages/es.ts";
 
 const language = "es";
@@ -9,6 +9,10 @@ const intl = createIntl({
   locale: language,
   messages: es,
 });
+
+export const links = () => {
+  return [...defaultLinks(), { rel: "canonical", href: "https://gasco.st/es" }];
+};
 
 export function meta() {
   return [

--- a/src/pages/home-hi.tsx
+++ b/src/pages/home-hi.tsx
@@ -1,5 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
+export { links } from "./home-defaults.ts";
 import hi from "../languages/hi.ts";
 
 const language = "hi";

--- a/src/pages/home-hi.tsx
+++ b/src/pages/home-hi.tsx
@@ -1,6 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
-export { links } from "./home-defaults.ts";
+import { links as defaultLinks } from "./home-defaults.ts";
 import hi from "../languages/hi.ts";
 
 const language = "hi";
@@ -9,6 +9,10 @@ const intl = createIntl({
   locale: language,
   messages: hi,
 });
+
+export const links = () => {
+  return [...defaultLinks(), { rel: "canonical", href: "https://gasco.st/hi" }];
+};
 
 export function meta() {
   return [

--- a/src/pages/home-hi.tsx
+++ b/src/pages/home-hi.tsx
@@ -1,6 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
-import { links as defaultLinks } from "./home-defaults.ts";
+import { defaultLinks } from "./home-defaults.ts";
 import hi from "../languages/hi.ts";
 
 const language = "hi";

--- a/src/pages/home-pt.tsx
+++ b/src/pages/home-pt.tsx
@@ -1,6 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
-import { links as defaultLinks } from "./home-defaults.ts";
+import { defaultLinks } from "./home-defaults.ts";
 import pt from "../languages/pt.ts";
 
 const language = "pt";

--- a/src/pages/home-pt.tsx
+++ b/src/pages/home-pt.tsx
@@ -1,5 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
+export { links } from "./home-defaults.ts";
 import pt from "../languages/pt.ts";
 
 const language = "pt";

--- a/src/pages/home-pt.tsx
+++ b/src/pages/home-pt.tsx
@@ -1,6 +1,6 @@
 import { I18nWrapper } from "@/I18nWrapper";
 import { createIntl } from "react-intl";
-export { links } from "./home-defaults.ts";
+import { links as defaultLinks } from "./home-defaults.ts";
 import pt from "../languages/pt.ts";
 
 const language = "pt";
@@ -9,6 +9,10 @@ const intl = createIntl({
   locale: language,
   messages: pt,
 });
+
+export const links = () => {
+  return [...defaultLinks(), { rel: "canonical", href: "https://gasco.st/pt" }];
+};
 
 export function meta() {
   return [


### PR DESCRIPTION
Use link tags to indicate canonical and alternate versions of the site

This change also improves the terms used for the Portuguese version of the site, ideally making it easier to find