### PR TITLE
:accessibility: feat: Handle numbers based on user settings

### DIFF
--- a/src/components/converter/converter.test.tsx
+++ b/src/components/converter/converter.test.tsx
@@ -234,11 +234,6 @@ describe("<Converter /> displayed in English for a pt-BR user located in India",
       ),
     ).toBeInTheDocument();
   });
-
-  test("formats the gas price numbers in the site language (English)", () => {
-    const { bottomPriceInput } = elements();
-    expect(bottomPriceInput).toHaveValue("0.00");
-  });
 });
 
 describe('<Converter siteLanguage="pt-BR" userLanguage="pt-BR" />', () => {

--- a/src/components/gas-price/gas-price.test.tsx
+++ b/src/components/gas-price/gas-price.test.tsx
@@ -9,9 +9,8 @@ import {
   gasPricesReducer,
   getInitialGasPrices,
 } from "@/context/gas-price-context";
-import en from "@/languages/en";
-import { IntlProvider } from "react-intl";
 import { useReducer } from "react";
+import { I18nProvider } from "@/context/i18n";
 
 describe("<GasPrice />", () => {
   const user = userEvent.setup();
@@ -22,7 +21,7 @@ describe("<GasPrice />", () => {
     );
 
     return (
-      <IntlProvider locale="en-US" messages={en}>
+      <I18nProvider siteLanguage="en">
         <GasPricesContext.Provider value={gasPrices}>
           <GasPricesDispatchContext.Provider value={dispatch}>
             <GasPrice
@@ -33,7 +32,7 @@ describe("<GasPrice />", () => {
             />
           </GasPricesDispatchContext.Provider>
         </GasPricesContext.Provider>
-      </IntlProvider>
+      </I18nProvider>
     );
   };
 

--- a/src/components/gas-price/gas-price.tsx
+++ b/src/components/gas-price/gas-price.tsx
@@ -49,7 +49,6 @@ function GasPrice({ label, gasPricesKey, siteLanguage }: GasPriceProps) {
           currency={currency}
           label={label}
           unit={unit}
-          siteLanguage={siteLanguage}
           number={number}
           onChange={(newValue) => {
             if (newValue === number) return; // Return early the value wouldn't change

--- a/src/components/number-input/number-input.test.tsx
+++ b/src/components/number-input/number-input.test.tsx
@@ -3,27 +3,24 @@ import { cleanup, render, screen } from "@testing-library/react";
 import NumberInput from "./number-input";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/vitest";
-import { IntlProvider } from "react-intl";
-import en from "../../languages/en";
 import { useState } from "react";
-import es from "@/languages/es";
+import { I18nProvider } from "@/context/i18n";
 
 describe("<Number />", () => {
   const user = userEvent.setup();
   const TestComponent = ({ ...props }) => {
     const [number, setNumber] = useState(0);
     return (
-      <IntlProvider locale="en-US" messages={en}>
+      <I18nProvider siteLanguage="en">
         <NumberInput
           currency="USD"
           label="Amount"
           onChange={setNumber}
           unit="liter"
-          siteLanguage="en-US"
           number={number}
           {...props}
         />
-      </IntlProvider>
+      </I18nProvider>
     );
   };
 
@@ -186,7 +183,7 @@ describe("<Number />", () => {
 
     cleanup();
     render(
-      <IntlProvider locale="en-US" messages={es}>
+      <I18nProvider siteLanguage="es">
         <NumberInput
           currency=""
           label="Amount"
@@ -194,10 +191,9 @@ describe("<Number />", () => {
             console.log("Test");
           }}
           unit="liter"
-          siteLanguage="en-US"
           number={0}
         />
-      </IntlProvider>,
+      </I18nProvider>,
     );
 
     expect(
@@ -206,5 +202,26 @@ describe("<Number />", () => {
         "Importe de amountPaidPerUnitGenericCurrency pagado por liter de gasolina",
       ).textContent,
     ).toBe("");
+  });
+
+  test("matches formatting to the browser's language, not the site language", async () => {
+    cleanup();
+    render(
+      <I18nProvider siteLanguage="pt" userLanguage="en-US">
+        <NumberInput
+          currency="USD"
+          label="Amount"
+          onChange={() => {
+            console.log("Test");
+          }}
+          unit="liter"
+          number={0}
+        />
+      </I18nProvider>,
+    );
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    expect(input.value).toBe("0.00");
   });
 });

--- a/src/components/number-input/number-input.test.tsx
+++ b/src/components/number-input/number-input.test.tsx
@@ -6,6 +6,7 @@ import "@testing-library/jest-dom/vitest";
 import { IntlProvider } from "react-intl";
 import en from "../../languages/en";
 import { useState } from "react";
+import es from "@/languages/es";
 
 describe("<Number />", () => {
   const user = userEvent.setup();
@@ -174,12 +175,36 @@ describe("<Number />", () => {
     expect(input.value).toBe("1.00");
   });
 
-  test.skip("can handle missing currency prop", async () => {
+  test("can handle missing currency prop", async () => {
     cleanup();
     render(<TestComponent currency="" />);
 
     expect(
-      screen.queryByRole("combobox", { name: "Currency" })?.textContent,
+      screen.getByLabelText("Amount of currency paid per liter of gas")
+        .textContent,
+    ).toBe("");
+
+    cleanup();
+    render(
+      <IntlProvider locale="en-US" messages={es}>
+        <NumberInput
+          currency=""
+          label="Amount"
+          onChange={() => {
+            console.log("Test");
+          }}
+          unit="liter"
+          siteLanguage="en-US"
+          number={0}
+        />
+      </IntlProvider>,
+    );
+
+    expect(
+      // TODO: Come up with a more elegant translation here
+      screen.getByLabelText(
+        "Importe de amountPaidPerUnitGenericCurrency pagado por liter de gasolina",
+      ).textContent,
     ).toBe("");
   });
 });

--- a/src/components/number-input/number-input.tsx
+++ b/src/components/number-input/number-input.tsx
@@ -72,7 +72,12 @@ const NumberInput = ({
       className="number"
       aria-label={intl.formatMessage(
         { id: "amountPaidPerUnit" },
-        { unit, currency },
+        {
+          unit,
+          currency:
+            currency ||
+            intl.formatMessage({ id: "amountPaidPerUnitGenericCurrency" }),
+        },
       )}
     />
   );

--- a/src/components/number-input/number-input.tsx
+++ b/src/components/number-input/number-input.tsx
@@ -5,10 +5,10 @@ import {
   getParsedNumber,
   isLegalPriceValue,
 } from "@/utils/number-format";
+import { useI18n } from "@/context/i18n";
 
 type NumberProps = {
   number: number;
-  siteLanguage: string;
   currency: string;
   label: string;
   onChange: (newValue: number) => void;
@@ -18,22 +18,24 @@ type NumberProps = {
 
 const NumberInput = ({
   number,
-  siteLanguage,
   currency,
   label,
   onChange,
   unit,
 }: NumberProps) => {
+  const {
+    state: { userLanguage },
+  } = useI18n();
   const intl = useIntl();
   const [displayNumber, setDisplayNumber] = useState(
-    getFormattedPrice(number, siteLanguage, currency),
+    getFormattedPrice(number, userLanguage, currency),
   );
   const [isNumberFocused, setIsNumberFocused] = useState(false);
 
   useEffect(() => {
     if (isNumberFocused) return;
 
-    setDisplayNumber(getFormattedPrice(number, siteLanguage, currency));
+    setDisplayNumber(getFormattedPrice(number, userLanguage, currency));
   }, [number, currency, isNumberFocused]);
 
   const handleDisplayNumberChange = (
@@ -41,11 +43,11 @@ const NumberInput = ({
   ) => {
     const displayNumber = event.target.value;
 
-    if (!isLegalPriceValue(displayNumber, siteLanguage)) return;
+    if (!isLegalPriceValue(displayNumber, userLanguage)) return;
 
     setDisplayNumber(displayNumber);
 
-    onChange(getParsedNumber(displayNumber, siteLanguage));
+    onChange(getParsedNumber(displayNumber, userLanguage));
   };
 
   return (
@@ -59,7 +61,7 @@ const NumberInput = ({
         setIsNumberFocused(true);
       }}
       onBlur={() => {
-        setDisplayNumber(getFormattedPrice(number, siteLanguage, currency));
+        setDisplayNumber(getFormattedPrice(number, userLanguage, currency));
         setIsNumberFocused(false);
       }}
       onChange={(value) => {

--- a/src/languages/en.ts
+++ b/src/languages/en.ts
@@ -33,6 +33,7 @@ export default {
   tinyNumber:
     "This amount is displayed as {displayNumber} {currency}, but the actual amount is less ({number} {currency})",
   amountPaidPerUnit: "Amount of {currency} paid per {unit} of gas",
+  amountPaidPerUnitGenericCurrency: "currency", // If we don't know what currency it is, we'll use this for "Amount of _________ paid per {unit} of gas"
 
   // LanguageSelect.tsx
   language: "Language",


### PR DESCRIPTION
Instead of relying on the site language to determine how numbers should be displayed and parsed, use the user's software settings. If the user's on an iPhone set up with English, the on-screen keyboard won't even allow them to enter commas (for the decimal point)