### PR TITLE
🧹 ci: Format latest.json update commits

### DIFF
--- a/.github/workflows/update-rates.yml
+++ b/.github/workflows/update-rates.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Commit changes
         uses: EndBug/add-and-commit@v9.1.4
         with:
-          message: "Update exchange rates"
+          message: "📈 chore: Update exchange rates"
           default_author: github_actions


### PR DESCRIPTION
I'd like to set up some pre-commit hooks to block non-"conventional commit" style commits to `main`

Since I've automated updating `latest.json` in my repo, this'll be necessary for it to still work