### PR TITLE
💾 feat: Preserve gas price values

### DIFF
--- a/e2e-tests/language-handling.spec.ts
+++ b/e2e-tests/language-handling.spec.ts
@@ -31,7 +31,7 @@ test.describe("An en-US user", () => {
       );
     });
 
-    test.only("preserves values when changing languages", async ({ page }) => {
+    test("preserves values when changing languages", async ({ page }) => {
       await page.locator("input").first().fill("1234");
       await page.getByRole("combobox", { name: "Language" }).click();
       await page.getByRole("option", { name: "Deutsch" }).click();
@@ -40,7 +40,7 @@ test.describe("An en-US user", () => {
         page.getByRole("heading", { name: "Gaskosten", exact: true }),
       ).toBeVisible();
 
-      await expect(page.locator("input").first()).toHaveValue("1234.00");
+      await expect(page.locator("input").first()).toHaveValue("1,234.00");
     });
   });
 

--- a/e2e-tests/language-handling.spec.ts
+++ b/e2e-tests/language-handling.spec.ts
@@ -30,6 +30,18 @@ test.describe("An en-US user", () => {
         "Deutsch",
       );
     });
+
+    test.only("preserves values when changing languages", async ({ page }) => {
+      await page.locator("input").first().fill("1234");
+      await page.getByRole("combobox", { name: "Language" }).click();
+      await page.getByRole("option", { name: "Deutsch" }).click();
+
+      await expect(
+        page.getByRole("heading", { name: "Gaskosten", exact: true }),
+      ).toBeVisible();
+
+      await expect(page.locator("input").first()).toHaveValue("1234.00");
+    });
   });
 
   test.describe("visiting the /de/ (German) homepage", () => {

--- a/src/context/gas-price-context.ts
+++ b/src/context/gas-price-context.ts
@@ -79,10 +79,10 @@ export function gasPricesReducer(
 
 export const getInitialGasPrices = (
   homeCountry: string,
-  userLocation: string,
+  userLocation: string | null,
 ): GasPrices => {
   // The imagined "normal" use-case is that someone's in a foreign country and wants to convert from foreign prices to home prices
-  let foreignCountry = userLocation;
+  let foreignCountry = userLocation || "US";
 
   const defaultGasPrices = {
     top: {

--- a/src/context/i18n.tsx
+++ b/src/context/i18n.tsx
@@ -119,7 +119,14 @@ const I18nProvider = ({
   });
   const value = { state, dispatch };
 
-  initializeUserLocation(dispatch, state);
+  async function startFetching() {
+    const countryCode = await fetchCountryCode();
+    dispatch({ type: "setUserLocation", payload: countryCode });
+  }
+
+  if (state.userLocation === null) {
+    startFetching();
+  }
 
   return (
     <I18nContext.Provider value={value}>
@@ -141,15 +148,4 @@ const useI18n = () => {
   }
   return context;
 };
-
-const initializeUserLocation = (dispatch: Dispatch, state: State) => {
-  async function startFetching() {
-    const countryCode = await fetchCountryCode();
-    dispatch({ type: "setUserLocation", payload: countryCode });
-  }
-  if (state.userLocation === null) {
-    startFetching();
-  }
-};
-
-export { I18nProvider, useI18n, initializeUserLocation };
+export { I18nProvider, useI18n };


### PR DESCRIPTION
This change preserves the user's gas price values when they leave and return to the page. This includes if they change languages or refresh the page.