### PR TITLE
🔗 feat: Send "Not Found" responses for missing pages

### DIFF
--- a/e2e-tests/404.spec.ts
+++ b/e2e-tests/404.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+const nonexistentPages = ["/$", "/t"];
+
+for (const url of nonexistentPages) {
+  test.describe(`${url} response`, () => {
+    test("throws a 404 error", async ({ request }) => {
+      const response = await request.get(url);
+
+      expect(response.status()).toBe(404);
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
-    "e2e": "npx playwright test",
+    "e2e": "npx playwright test --reporter=list",
     "rates:update": "node update_latest",
     "start": "react-router-serve build/server/index.js",
     "typecheck": "react-router typegen && tsc",

--- a/src/pages/catchall.tsx
+++ b/src/pages/catchall.tsx
@@ -1,5 +1,3 @@
-import { redirect } from "react-router";
-
 export async function loader() {
-  return redirect("/");
+  throw new Response(null, { status: 404, statusText: "Not Found" });
 }


### PR DESCRIPTION
This change updates the "catchall" to throw a 404 response instead of returning English homepage content