### PR TITLE
🐎 feat: Prerender everything

### DIFF
--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -2,7 +2,5 @@ import type { Config } from "@react-router/dev/config";
 
 export default {
   appDirectory: "src",
-  async prerender() {
-    return ["/", "/de/", "/es/", "/pt/", "/hi/"];
-  },
+  prerender: true,
 } satisfies Config;

--- a/src/components/language-select/language-select.tsx
+++ b/src/components/language-select/language-select.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router";
 import "./language-select.css";
 import * as Flag from "country-flag-icons/react/3x2";
 import { supportedLanguages } from "@/utils/supported-languages";
+import { useState } from "react";
 
 type LanguageSelectProps = {
   siteLanguage: string;
@@ -15,31 +16,40 @@ const LanguageSelect = ({ siteLanguage }: LanguageSelectProps) => {
   const getFlagIcon = (country: string) => {
     switch (country) {
       case "US":
-        return <Flag.US height={14} />;
+        return <Flag.US height={14} aria-hidden="true" />;
       case "DE":
-        return <Flag.DE height={14} />;
+        return <Flag.DE height={14} aria-hidden="true" />;
       case "IN":
-        return <Flag.IN height={14} />;
+        return <Flag.IN height={14} aria-hidden="true" />;
       case "BR":
-        return <Flag.BR height={14} />;
+        return <Flag.BR height={14} aria-hidden="true" />;
       case "MX":
-        return <Flag.MX height={14} />;
+        return <Flag.MX height={14} aria-hidden="true" />;
       default:
-        return <Flag.EU height={14} />;
+        return <Flag.EU height={14} aria-hidden="true" />;
     }
   };
 
   const navigate = useNavigate();
   // handleLanguageChange function: Handles language changes by navigating to its URL
-  const handleLanguageChange = (newLanguage: string) => {
+  const handleLanguageChange = (newLanguageId: string) => {
+    if (newLanguageId === currentLanguage.id) return;
+
+    const newLanguage = supportedLanguages.find(
+      ({ id }) => id === newLanguageId,
+    );
+    if (newLanguage === undefined) return;
+
+    setCurrentLanguage(newLanguage);
     // The site's English version has a special URL ("/" instead of "/en")
     const newPath =
-      supportedLanguages.find(({ id }) => id === newLanguage)?.path || "/";
+      supportedLanguages.find(({ id }) => id === newLanguageId)?.path || "/";
     navigate(newPath);
   };
-  const currentLanguage =
+  const [currentLanguage, setCurrentLanguage] = useState(
     supportedLanguages.find(({ id }) => id === siteLanguage) ||
-    supportedLanguages[0];
+      supportedLanguages[0],
+  );
   return (
     <form className="my-4 language-form">
       <label
@@ -52,7 +62,7 @@ const LanguageSelect = ({ siteLanguage }: LanguageSelectProps) => {
       <Ariakit.SelectProvider
         defaultValue={siteLanguage}
         setValue={(newValue) => {
-          handleLanguageChange(String(newValue));
+          handleLanguageChange(newValue);
         }}
         placement="bottom"
         value={currentLanguage.id}
@@ -77,12 +87,17 @@ const LanguageSelect = ({ siteLanguage }: LanguageSelectProps) => {
             ({ id, countryCode, languageName, countryName }) => {
               return (
                 <Ariakit.SelectItem
-                  className="select-item"
+                  className={`select-item ${id === currentLanguage.id ? "selected" : ""}`}
                   key={id}
                   value={id}
                   id={id}
+                  lang={id} // This is useful for screen readers; we're about to render text in a different language
                 >
-                  {currentLanguage.id === id ? "✓" : ""}
+                  {currentLanguage.id === id ? (
+                    <span aria-hidden="true">✓</span>
+                  ) : (
+                    ""
+                  )}
                   {getFlagIcon(countryCode)}
                   {languageName} {countryName ? `(${countryName})` : ""}
                 </Ariakit.SelectItem>


### PR DESCRIPTION
This change updates the syntax for pre-rendering pages.

Instead of listing which specific pages to pre-render (and returning it from a function for no good reason), now the app pre-renders _all_ pages

I've also updated the language select to be more accessible: highlight current value, hide presentational stuff from screen readers

Close #136